### PR TITLE
Add JSON responses for AjaxSupport

### DIFF
--- a/server/gokbg3/grails-app/taglib/InplaceTagLib.groovy
+++ b/server/gokbg3/grails-app/taglib/InplaceTagLib.groovy
@@ -101,7 +101,7 @@ class InplaceTagLib {
     def data_link = null
     switch ( attrs.type ) {
       case 'date':
-        data_link = createLink(controller:'ajaxSupport', action: 'editableSetValue', params:[type:'date', format: (attrs."data-format"?:'yyyy-MM-dd')])
+        data_link = createLink(controller:'ajaxSupport', action: 'editableSetValue', params:[type:'date', dateFormat: (attrs."data-format"?:'yyyy-MM-dd')])
 //        out << " data-type='dateui' data-format='${attrs."data-format"?:'YYYY-MM-DD'}' data-datepicker='{minYear : 1900,smartDays:true}' data-viewformat='MM/DD/YYYY'"
 //        if (!attrs."data-value") {
 //          if (owner[attrs.field]) {

--- a/server/gokbg3/grails-app/views/apptemplates/_combosByType.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_combosByType.gsp
@@ -35,7 +35,7 @@
             <g:link
               controller='workflow'
               action='deleteCombo'
-              params="${['__context':combooid,'fragment':fragment]}"
+              params="${['id':row.id,'fragment':fragment]}"
               class="confirm-click btn-delete"
               data-confirm-message="Are you sure you wish to delete this ${row.toComponent.getNiceName()}?" >Delete</g:link>
           </g:if>

--- a/server/gokbg3/grails-app/views/apptemplates/_combosByType.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_combosByType.gsp
@@ -33,8 +33,8 @@
         <td>
           <g:if test="${d.isEditable() && (d.respondsTo('curatoryGroups') ? (!d.curatoryGroups ? true : cur) : true)}">
             <g:link
-              controller='ajaxSupport'
-              action='delete'
+              controller='workflow'
+              action='deleteCombo'
               params="${['__context':combooid,'fragment':fragment]}"
               class="confirm-click btn-delete"
               data-confirm-message="Are you sure you wish to delete this ${row.toComponent.getNiceName()}?" >Delete</g:link>

--- a/server/gokbg3/grails-app/views/apptemplates/_imprint.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_imprint.gsp
@@ -18,7 +18,7 @@
     ${d.currentOwner}&nbsp;
   </dd>
 
-  <dt>
+  <dt class="dt-label">
     <g:annotatedLabel owner="${d}" property="owners">Owners</g:annotatedLabel>
   </dt>
 
@@ -50,9 +50,9 @@
     <g:form controller="ajaxSupport" action="addToStdCollection" class="form-inline">
       <input type="hidden" name="__context" value="${d.class.name}:${d.id}" />
       <input type="hidden" name="__property" value="owners" />
-      <dt>Add Owner:</td>
+      <dt class="dt-label">Add Owner:</td>
       <dd>
-        <g:simpleReferenceTypedown class="form-control input-xxlarge" name="__relatedObject" baseClass="org.gokb.cred.Org" filter1="Current"/><button type="submit" class="btn btn-default btn-primary btn-sm ">Add</button>
+        <g:simpleReferenceTypedown class="form-inline select-ml" name="__relatedObject" baseClass="org.gokb.cred.Org" filter1="Current"/>&nbsp;<button type="submit" class="btn btn-default btn-primary">Add</button>
       </dd>
     </g:form>
   </g:if>

--- a/server/gokbg3/grails-app/views/apptemplates/_org.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_org.gsp
@@ -113,17 +113,12 @@
 			<g:render template="/tabTemplates/showVariantnames" model="${[d:d, showActions:true]}" />
 			<div class="tab-pane" id="ids">
 				<g:if test="${d.id != null}">
-					<dl>
-						<dt>
-							<g:annotatedLabel owner="${d}" property="ids">IDs</g:annotatedLabel>
-						</dt>
-						<dd>
-							<g:render template="/apptemplates/comboList"
-								model="${[d:d, property:'ids', cols:[[expr:'namespace.value',colhead:'Namespace'],[expr:'value',colhead:'Identifier']]]}" />
-                                                        <g:render template="/apptemplates/addIdentifier" model="${[d:d]}"/>
+                                    <g:render template="/apptemplates/combosByType"
+                                      model="${[d:d, property:'ids', fragment:'ids', cols:[
+                                                [expr:'toComponent.namespace.value', colhead:'Namespace'],
+                                                [expr:'toComponent.value', colhead:'ID', action:'link']]]}" />
 
-						</dd>
-					</dl>
+                                    <g:render template="/apptemplates/addIdentifier" model="${[d:d, hash:'#ids']}"/>
 				</g:if>
 			</div>
             <div class="tab-pane" id="relationships">

--- a/server/gokbg3/grails-app/views/apptemplates/_package.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_package.gsp
@@ -135,6 +135,7 @@
               <input type="hidden" name="__context" value="${d.class?.name}:${d.id}" />
               <input type="hidden" name="__newObjectClass" value="org.gokb.cred.TitleInstancePackagePlatform" />
               <input type="hidden" name="__addToColl" value="tipps" />
+              <input type="hidden" name="__showNew" value="true" />
               <dl class="dl-horizontal">
                 <dt class="dt-label">Title</dt>
                 <dd>

--- a/server/gokbg3/grails-app/views/tabTemplates/_showVariantnames.gsp
+++ b/server/gokbg3/grails-app/views/tabTemplates/_showVariantnames.gsp
@@ -51,6 +51,7 @@
               <input type="hidden" name="__newObjectClass"
                 value="org.gokb.cred.KBComponentVariantName" />
               <input type="hidden" name="__recip" value="owner" />
+              <input type="hidden" name="fragment" value="altnames" />
               <dt class="dt-label">Variant Name</dt>
               <dd>
                 <input type="text" class="form-control select-m" name="variantName" />


### PR DESCRIPTION
This adds withFormat blocks with JSON serializations to actions which previously had only redirects defined. As a result, these actions will now also be usable outside of the template context by requesting JSON.

The default JSON return object contains a status string field `result` (with values 'OK' or 'ERROR'), as well as the parameter map `params`. If the action encounters errors which would result in a flash message in html context, these messages will be returned in an array `errors`. If the action creates a new object, its JSON serialization will be returned as `new_object`, and its OID will be returned as `new_oid`.