### PR TITLE
Feature platform cleanup

### DIFF
--- a/server/gokbg3/grails-app/controllers/org/gokb/AdminController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/AdminController.groovy
@@ -364,6 +364,19 @@ class AdminController {
     render(view: "logViewer", model: logViewer())
   }
 
+  def cleanupPlatforms() {
+    Job j = concurrencyManagerService.createJob { Job j ->
+      cleanupService.deleteNoUrlPlatforms(j)
+    }.startOrQueue()
+
+    log.debug("Triggering cleanup task. Started job #${j.id}")
+
+    j.description = "Platform Cleanup"
+    j.startTime = new Date()
+
+    render(view: "logViewer", model: logViewer())
+  }
+
   def exportGroups () {
     def result = [:]
     CuratoryGroup.createCriteria().list ({

--- a/server/gokbg3/grails-app/services/org/gokb/CleanupService.groovy
+++ b/server/gokbg3/grails-app/services/org/gokb/CleanupService.groovy
@@ -181,7 +181,7 @@ class CleanupService {
     def status_deleted = RefdataCategory.lookupOrCreate('KBComponent.Status', 'Deleted')
     def status_current = RefdataCategory.lookupOrCreate('KBComponent.Status', 'Current')
 
-    def delete_candidates = Platform.executeQuery('from Platform as plt where plt.primaryUrl IS NULL')
+    def delete_candidates = Platform.executeQuery('from Platform as plt where plt.primaryUrl IS NULL and plt.status = ?', [status_current])
 
     delete_candidates.each { ptr ->
       def repl_crit = Platform.createCriteria()

--- a/server/gokbg3/grails-app/views/layouts/sb-admin.gsp
+++ b/server/gokbg3/grails-app/views/layouts/sb-admin.gsp
@@ -185,6 +185,7 @@
                       <li><g:link controller="admin" action="recalculateStats" onclick="return confirm('Are you sure?')"><i class="fa fa-angle-double-right fa-fw"></i> Recalculate Statistics</g:link></li>
                       <li><g:link controller="admin" action="convertTippCoverages" onclick="return confirm('Are you sure?')"><i class="fa fa-angle-double-right fa-fw"></i> Convert old coverage statements</g:link></li>
                       <li><g:link controller="admin" action="cleanup" onclick="return confirm('Are you sure?')"><i class="fa fa-angle-double-right fa-fw"></i> Expunge Deleted Records</g:link></li>
+                      <li><g:link controller="admin" action="cleanupPlatforms" onclick="return confirm('Are you sure?')"><i class="fa fa-angle-double-right fa-fw"></i> Deprecate Platforms Without URLs</g:link></li>
                       <li><g:link controller="admin" action="cleanupRejected" onclick="return confirm('Are you sure?')"><i class="fa fa-angle-double-right fa-fw"></i> Expunge Rejected Records</g:link></li>
                     <li><g:link controller="admin" action="cleanupOrphanedTipps" onclick="return confirm('Are you sure?')"><i class="fa fa-angle-double-right fa-fw"></i> Expunge Orphaned TIPPs</g:link></li>
                       <li><g:link controller="admin" action="ensureUuids" onclick="return confirm('Are you sure?')"><i class="fa fa-angle-double-right fa-fw"></i> Ensure UUIDs</g:link></li>


### PR DESCRIPTION
This action deletes all platforms without a primaryUrl if it finds a platform with the same name, and transfers all connected combos to the new platform.