### PR TITLE
Move api functions & mark workflows as transactional

### DIFF
--- a/server/gokbg3/grails-app/controllers/org/gokb/WorkflowController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/WorkflowController.groovy
@@ -9,6 +9,7 @@ import org.hibernate.ScrollMode
 import org.hibernate.ScrollableResults
 import org.hibernate.type.*
 import org.hibernate.Hibernate
+import grails.gorm.transactions.Transactional
 
 
 class WorkflowController {
@@ -822,7 +823,7 @@ class WorkflowController {
     result
   }
 
-
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def processTitleChange(activity_record, activity_data) {
 
@@ -932,6 +933,7 @@ class WorkflowController {
     activity_record.save(flush:true)
   }
   
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def processTitleMerge(activity_record, activity_data, merge_params) {
     log.debug("processTitleMerge ${params}\n\n ${activity_data}");
@@ -1099,6 +1101,7 @@ class WorkflowController {
     activity_record.save(flush:true)
   }
 
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def processTitleTransfer(activity_record, activity_data) {
     log.debug("processTitleTransfer ${params}\n\n ${activity_data}");
@@ -1220,6 +1223,7 @@ class WorkflowController {
     activity_record.save(flush:true)
   }
 
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def processPackageReplacement() {
     def retired_status = RefdataCategory.lookupOrCreate('KBComponent.Status', 'Retired')
@@ -1253,6 +1257,7 @@ class WorkflowController {
     render view:'platformReplacementResult' , model:[result:result]
   }
 
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def processTippRetire() {
     log.debug("processTippRetire ${params}")
@@ -1292,14 +1297,21 @@ class WorkflowController {
     }
   }
 
+  /**
+   *  authorizeVariant : Used to replace the name of a component by one of its variant names.
+   * @param id : The id of the variant name
+   */
+
+  // Deprecated – use action in AjaxSupport instead
+  @Deprecated
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def authorizeVariant() {
     log.debug("${params}");
-    def result = [:]
-    result.ref=request.getHeader('referer')
+    def result = ['result':'OK', 'params':params]
     def variant = KBComponentVariantName.get(params.id)
 
-    if ( variant != null ) {
+    if ( variant != null && variant.owner.isEditable()) {
       // Does the current owner.name exist in a variant? If not, we should create one so we don't loose the info
       def current_name_as_variant = variant.owner.variantNames.find { it.variantName == variant.owner.name }
       if ( current_name_as_variant == null ) {
@@ -1319,32 +1331,111 @@ class WorkflowController {
       }
       variant.variantType = RefdataCategory.lookupOrCreate('KBComponentVariantName.VariantType', 'Authorized')
       variant.owner.name = variant.variantName
-      variant.owner.save(flush:true);
+
+      if (variant.owner.validate()) {
+        variant.owner.save(flush:true);
+      }
+      else {
+        result.result = 'ERROR'
+        result.code = 400
+        result.message = "This name already belongs to another component of the same type!"
+        flash.error = "This name already belongs to another component of the same type!"
+      }
     }
-    redirect(url: result.ref)
+    else if (!variant) {
+      result.result = 'ERROR'
+      result.code = 404
+      result.message = "Could not find variant!"
+    }
+    else {
+      result.result = 'ERROR'
+      result.code = 403
+      result.message = "Owner object is not editable!"
+      flash.error = "Owner object is not editable!"
+    }
+
+    withFormat {
+      html {
+        def redirect_to = request.getHeader('referer')
+
+        if ( params.redirect ) {
+          redirect_to = params.redirect
+        }
+        else if ( ( params.fragment ) && ( params.fragment.length() > 0 ) ) {
+          redirect_to = "${redirect_to}#${params.fragment}"
+        }
+      }
+      json {
+        render result as JSON
+      }
+    }
   }
 
+  /**
+   *  deleteVariant : Used to delete a variant name of a component.
+   * @param id : The id of the variant name
+   */
+
+  // Deprecated – use action in AjaxSupport instead
+  @Deprecated
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def deleteVariant() {
     log.debug("${params}");
-    def result = [:]
-    result.ref=request.getHeader('referer')
+    def result = ['result':'OK', 'params': params]
     def variant = KBComponentVariantName.get(params.id)
-    def variantOwner = variant.owner
-    def variantName = variant.variantName
+
     if ( variant != null && variantOwner.isEditable() ) {
+      def variantOwner = variant.owner
+      def variantName = variant.variantName
+
       variant.delete()
       variantOwner.lastUpdateComment = "Deleted Alternate Name ${variantName}."
       variantOwner.save(flush: true)
+
+      result.owner_oid = "${variantOwner.class.name}:${variantOwner.id}"
+      result.deleted_variant = "${variantName}"
     }
-    redirect(url: result.ref)
+    else if (!variant) {
+      result.result = 'ERROR'
+      result.code = 404
+      result.message = "Could not find variant!"
+    }
+    else {
+      result.result = 'ERROR'
+      result.code = 403
+      result.message = "Owner object is not editable!"
+    }
+
+    withFormat {
+      html {
+        def redirect_to = request.getHeader('referer')
+
+        if ( params.redirect ) {
+          redirect_to = params.redirect
+        }
+        else if ( ( params.fragment ) && ( params.fragment.length() > 0 ) ) {
+          redirect_to = "${redirect_to}#${params.fragment}"
+        }
+      }
+      json {
+        render result as JSON
+      }
+    }
   }
 
+  /**
+   *  deleteCoverageStatement : Used to delete a TIPPCoverageStatement.
+   * @param id : The id of the coverage statement object
+   */
+
+  // Deprecated – use action in AjaxSupport instead
+  @Deprecated
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def deleteCoverageStatement() {
     log.debug("${params}");
-    def result = [:]
-    result.ref=request.getHeader('referer')
+    def result = ['result':'OK', 'params': params]
     def tcs = TIPPCoverageStatement.get(params.id)
     def tipp = tcs.owner
 
@@ -1353,7 +1444,32 @@ class WorkflowController {
       tipp.lastUpdateComment = "Deleted Coverage Statement."
       tipp.save(flush: true)
     }
-    redirect(url: result.ref)
+    else if (!tcs) {
+      result.result = 'ERROR'
+      result.code = 404
+      result.message = "Could not find coverage statement!"
+    }
+    else {
+      result.result = 'ERROR'
+      result.code = 403
+      result.message = "This TIPP is not editable!"
+    }
+
+    withFormat {
+      html {
+        def redirect_to = request.getHeader('referer')
+
+        if ( params.redirect ) {
+          redirect_to = params.redirect
+        }
+        else if ( ( params.fragment ) && ( params.fragment.length() > 0 ) ) {
+          redirect_to = "${redirect_to}#${params.fragment}"
+        }
+      }
+      json {
+        render result as JSON
+      }
+    }
   }
 
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
@@ -1406,6 +1522,7 @@ class WorkflowController {
     redirect(url: result.ref)
   }
 
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def processRRTransfer() {
     def result = [:]
@@ -1429,6 +1546,7 @@ class WorkflowController {
     redirect(url: result.ref)
   }
 
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def createTitleHistoryEvent() {
 
@@ -1476,6 +1594,7 @@ class WorkflowController {
     redirect(url: result.ref)
   }
 
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def deleteTitleHistoryEvent() {
 
@@ -1727,6 +1846,7 @@ class WorkflowController {
     redirect(url: result.ref)
   }
 
+  @Transactional
   @Secured(['ROLE_EDITOR', 'IS_AUTHENTICATED_FULLY'])
   def deprecateOrg() {
     def result=[:]
@@ -1786,6 +1906,7 @@ class WorkflowController {
     }
   }
 
+  @Transactional
   @Secured(['ROLE_EDITOR', 'IS_AUTHENTICATED_FULLY'])
   def deprecateDeleteOrg() {
     log.debug("deprecateDeleteOrg ${params}");
@@ -1803,7 +1924,15 @@ class WorkflowController {
     result
   }
 
-  @Secured(['ROLE_CONTRIBUTOR', 'IS_AUTHENTICATED_FULLY'])
+  /**
+   *  deleteCombo : Used to delete a combo object.
+   * @param id : The id of the combo object
+   */
+
+  // Deprecated – use action in AjaxSupport instead
+  @Deprecated
+  @Transactional
+  @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def deleteCombo() {
     Combo c = Combo.get(params.id);
     if (c.fromComponent.isEditable()) {
@@ -1813,9 +1942,27 @@ class WorkflowController {
     else{
       log.debug("Not deleting combo.. no edit permissions on fromComponent!")
     }
-    redirect(url: request.getHeader('referer'));
+
+    withFormat {
+      html {
+        def redirect_to = request.getHeader('referer')
+
+        if ( params.redirect ) {
+          redirect_to = params.redirect
+        }
+        else if ( ( params.fragment ) && ( params.fragment.length() > 0 ) ) {
+          redirect_to = "${redirect_to}#${params.fragment}"
+        }
+
+        redirect(url: redirect_to);
+      }
+      json {
+        render result as JSON
+      }
+    }
   }
 
+  @Transactional
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   private def verifyTitleList(packages_to_verify) {
     def user = springSecurityService.currentUser

--- a/server/gokbg3/grails-app/views/apptemplates/_book.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_book.gsp
@@ -285,7 +285,7 @@
                 <td><g:xEditableRefData owner="${p}" field="status" config='Combo.Status' /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="startDate" type="date" /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="endDate" type="date" /></td>
-                <td><g:if test="${d.isEditable()}"><g:link controller="workflow" action="deleteCombo" id="${p.id}">Delete</g:link></g:if></td>
+                <td><g:if test="${d.isEditable()}"><g:link controller="ajaxSupport" action="deleteCombo" id="${p.id}">Delete</g:link></g:if></td>
               </tr>
             </g:each>
           </tbody>

--- a/server/gokbg3/grails-app/views/apptemplates/_combosByType.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_combosByType.gsp
@@ -33,7 +33,7 @@
         <td>
           <g:if test="${d.isEditable() && (d.respondsTo('curatoryGroups') ? (!d.curatoryGroups ? true : cur) : true)}">
             <g:link
-              controller='workflow'
+              controller='ajaxSupport'
               action='deleteCombo'
               params="${['id':row.id,'fragment':fragment]}"
               class="confirm-click btn-delete"

--- a/server/gokbg3/grails-app/views/apptemplates/_database.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_database.gsp
@@ -296,7 +296,7 @@
                 <td><g:xEditableRefData owner="${p}" field="status" config='Combo.Status' /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="startDate" type="date" /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="endDate" type="date" /></td>
-                <td><g:if test="${d.isEditable()}"><g:link controller="workflow" action="deleteCombo" id="${p.id}">Delete</g:link></g:if></td>
+                <td><g:if test="${d.isEditable()}"><g:link controller="ajaxSupport" action="deleteCombo" id="${p.id}">Delete</g:link></g:if></td>
               </tr>
             </g:each>
           </tbody>

--- a/server/gokbg3/grails-app/views/apptemplates/_imprint.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_imprint.gsp
@@ -40,7 +40,7 @@
             <td><g:xEditableRefData owner="${p}" field="status" config='Combo.Status' /></td>
             <td><g:xEditable class="ipe" owner="${p}" field="startDate" type="date" /></td>
             <td><g:xEditable class="ipe" owner="${p}" field="endDate" type="date" /></td>
-            <td><g:link controller="workflow" action="deleteCombo" id="${p.id}">Delete</g:link></td>
+            <td><g:link controller="ajaxSupport" action="deleteCombo" id="${p.id}">Delete</g:link></td>
           </tr>
         </g:each>
       </tbody>

--- a/server/gokbg3/grails-app/views/apptemplates/_journal.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_journal.gsp
@@ -292,7 +292,7 @@
                 <td><g:xEditableRefData owner="${p}" field="status" config='Combo.Status' /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="startDate" type="date" /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="endDate" type="date" /></td>
-                <td><g:if test="${d.isEditable()}"><g:link controller="workflow" action="deleteCombo" id="${p.id}">Delete</g:link></g:if></td>
+                <td><g:if test="${d.isEditable()}"><g:link controller="ajaxSupport" action="deleteCombo" id="${p.id}">Delete</g:link></g:if></td>
               </tr>
             </g:each>
           </tbody>

--- a/server/gokbg3/grails-app/views/apptemplates/_org.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_org.gsp
@@ -188,7 +188,7 @@
                             <td><g:xEditableRefData owner="${p}" field="status" config='Combo.Status' /></td>
                             <td><g:xEditable class="ipe" owner="${p}" field="startDate" type="date" /></td>
                             <td><g:xEditable class="ipe" owner="${p}" field="endDate" type="date" /></td>
-                            <td><g:link controller="workflow" action="deleteCombo" id="${p.id}">Delete</g:link></td>
+                            <td><g:link controller="ajaxSupport" action="deleteCombo" id="${p.id}">Delete</g:link></td>
                           </tr>
                         </g:each>
                       </tbody>

--- a/server/gokbg3/grails-app/views/apptemplates/_title.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_title.gsp
@@ -302,7 +302,7 @@
                 <td><g:xEditableRefData owner="${p}" field="status" config='Combo.Status' /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="startDate" type="date" /></td>
                 <td><g:xEditable class="ipe" owner="${p}" field="endDate" type="date" /></td>
-                <td><g:link controller="workflow" action="deleteCombo" id="${p.id}">Delete</g:link></td>
+                <td><g:link controller="ajaxSupport" action="deleteCombo" id="${p.id}">Delete</g:link></td>
               </tr>
             </g:each>
           </tbody>

--- a/server/gokbg3/grails-app/views/tabTemplates/_showVariantnames.gsp
+++ b/server/gokbg3/grails-app/views/tabTemplates/_showVariantnames.gsp
@@ -29,9 +29,9 @@
                 <td><g:xEditableRefData owner="${v}" field="locale" config='KBComponentVariantName.Locale' /></td>
                 <td>
                   <g:if test="${ editable && showActions }">
-                              <g:link controller="workflow" action="AuthorizeVariant" id="${v.id}">Make Authorized</g:link>,
-                              <g:link controller="workflow" class="confirm-click" data-confirm-message="Are you sure you wish to delete this Variant?"
-                                action="DeleteVariant" id="${v.id}" >Delete</g:link>
+                              <g:link controller="ajaxSupport" action="authorizeVariant" id="${v.id}">Make Authorized</g:link>,
+                              <g:link controller="ajaxSupport" class="confirm-click" data-confirm-message="Are you sure you wish to delete this Variant?"
+                                action="deleteVariant" id="${v.id}" >Delete</g:link>
                   </g:if>
                 </td>
               </tr>


### PR DESCRIPTION
To better thematically separate the WorkflowController and AjaxSupportController, this moves some actions that had no real workflow at all into AjaxSupport, while providing them with proper JSON response serializations as well. The old functions in WorkflowController are now marked as deprecated. Links from within templates to these actions have been adjusted accordingly.

This also adds missing annotations to WorkflowController actions marking them transactional.
