### PR TITLE
Domains - add getNiceName to KBComponent and override when needed, add uuid index

### DIFF
--- a/server/gokbg3/grails-app/conf/application.groovy
+++ b/server/gokbg3/grails-app/conf/application.groovy
@@ -1113,7 +1113,7 @@ globalSearchTemplates = [
       ],
       qbeResults:[
         [heading:'Name', property:'component.name', link:[controller:'resource',action:'show',id:'x.r.component.class.name+\':\'+x.r.component.id'] ],
-        [heading:'Type', property:'component.getNiceName()'],
+        [heading:'Type', property:'component.niceName'],
         [heading:'Last Update on', property:'component.lastUpdated'],
         [heading:'Last Update by', property:'component.lastUpdatedBy?.username'],
         [heading:'Last Update Comment', property:'component.lastUpdateComment']

--- a/server/gokbg3/grails-app/controllers/org/gokb/SearchController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/SearchController.groovy
@@ -203,7 +203,7 @@ class SearchController {
                 cobj = cobj.value
               }
               else {
-                if ( cobj && cobj[sp] != null ) {
+                if ( cobj && KBComponent.has(cobj, sp)) {
                   cobj = cobj[sp]
 
                   if (ppath.size() > 1 && idx == ppath.size()-2) {

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/BookInstance.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/BookInstance.groovy
@@ -57,6 +57,7 @@ class BookInstance extends TitleInstance {
       "${this.class.name}:${id}"
   }
 
+  @Override
   public String getNiceName() {
     return "Book";
   }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/CuratoryGroup.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/CuratoryGroup.groovy
@@ -44,6 +44,11 @@ class CuratoryGroup extends KBComponent {
       }
     })
   }
+
+  @Override
+  public String getNiceName() {
+    return "Curatory Group";
+  }
   
   static def refdataFind(params) {
     def result = [];

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/DatabaseInstance.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/DatabaseInstance.groovy
@@ -18,6 +18,7 @@ class DatabaseInstance extends TitleInstance {
   static constraints = {
   }
 
+  @Override
   public String getNiceName() {
     return "Database";
   }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Imprint.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Imprint.groovy
@@ -29,10 +29,6 @@ class Imprint extends KBComponent {
 //     ]
 //   }
 
-  public String getNiceName() {
-    return "Imprint";
-  }
-
   public Org getCurrentOwner() {
     def result = null;
     def owner_combos = getCombosByPropertyName('owners')

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/JournalInstance.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/JournalInstance.groovy
@@ -25,6 +25,7 @@ class JournalInstance extends TitleInstance {
       "${this.class.name}:${id}"
   }
 
+  @Override
   public String getNiceName() {
     return "Journal";
   }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/KBComponent.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/KBComponent.groovy
@@ -401,7 +401,7 @@ where cp.owner = :c
   static mapping = {
     tablePerHierarchy false
     id column:'kbc_id'
-    uuid column:'kbc_uuid', type:'text'
+    uuid column:'kbc_uuid', type:'text', index:'kbc_uuid_idx'
     version column:'kbc_version'
     name column:'kbc_name', type:'text', index:'kbc_name_idx'
     // Removed auto creation of norm_id_value_idx from here and identifier - MANUALLY CREATE
@@ -926,6 +926,10 @@ where cp.owner = :c
 
   public String toString() {
     "${name?:''} (${getNiceName()} ${this.id})".toString()
+  }
+
+  public String getNiceName() {
+    "${this.class.getSimpleName()}"
   }
 
   /**

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Org.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Org.groovy
@@ -132,6 +132,7 @@ class Org extends KBComponent {
     located_org
   }
 
+  @Override
   public String getNiceName() {
     return "Organization";
   }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Source.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Source.groovy
@@ -37,10 +37,6 @@ class Source extends KBComponent {
     ruleset(nullable:true, blank:true)
   }
 
-  public String getNiceName() {
-    return "Source";
-  }
-
   static def refdataFind(params) {
     def result = [];
     def status_deleted = RefdataCategory.lookupOrCreate(KBComponent.RD_STATUS, KBComponent.STATUS_DELETED)

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstance.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstance.groovy
@@ -131,6 +131,7 @@ class TitleInstance extends KBComponent {
     ]
   }
 
+  @Override
   public String getNiceName() {
     return "Title";
   }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePackagePlatform.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePackagePlatform.groovy
@@ -137,6 +137,7 @@ class TitleInstancePackagePlatform extends KBComponent {
     ]
   }
 
+  @Override
   public String getNiceName() {
 	return "TIPP";
   }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePlatform.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePlatform.groovy
@@ -38,6 +38,7 @@ class TitleInstancePlatform extends KBComponent {
     ]
   }
 
+  @Override
   public String getNiceName() {
 	return "TIPL";
   }


### PR DESCRIPTION
Instead of only defining `getNiceName()` for components where there is a need for a common domain name different from their simpleName, now the field is defined for all KBComponents and overriden in those cases.

This also prompts the creation of a missing database index for component uuids.