### PR TITLE
If val contains the key 'id' rather use its value than val itself

### DIFF
--- a/server/gokbg3/grails-app/services/gokbg3/RestMappingService.groovy
+++ b/server/gokbg3/grails-app/services/gokbg3/RestMappingService.groovy
@@ -321,7 +321,7 @@ class RestMappingService {
           }
         }
       } else {
-        def linkObj = ptype.get(val)
+        def linkObj = ptype.get(val.id?val.id:val)
 
         if (linkObj) {
           obj[prop] = linkObj


### PR DESCRIPTION
self-explaining one-liner