### PR TITLE
replace upsert for rest save actions

### DIFF
--- a/server/gokbg3/grails-app/controllers/gokbg3/UrlMappings.groovy
+++ b/server/gokbg3/grails-app/controllers/gokbg3/UrlMappings.groovy
@@ -100,6 +100,13 @@ class UrlMappings {
       delete "/tipps/$id"(controller: 'tipp', namespace: 'rest', action: 'delete')
       post "/tipps"(controller: 'tipp', namespace: 'rest', action: 'save')
       get "/tipps"(controller: 'tipp', namespace: 'rest', action: 'index')
+
+      get "/package-titles/$id/coverage"(controller: 'tipp', namespace: 'rest', action: 'getCoverage')
+      get "/package-titles/$id"(controller: 'tipp', namespace: 'rest', action: 'show')
+      put "/package-titles/$id"(controller: 'tipp', namespace: 'rest', action: 'update')
+      delete "/package-titles/$id"(controller: 'tipp', namespace: 'rest', action: 'delete')
+      post "/package-titles"(controller: 'tipp', namespace: 'rest', action: 'save')
+      get "/package-titles"(controller: 'tipp', namespace: 'rest', action: 'index')
       
       get "/package-scopes" (controller: 'refdata', namespace: 'rest', action: 'packageScope')
     }

--- a/server/gokbg3/grails-app/controllers/org/gokb/IntegrationController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/IntegrationController.groovy
@@ -887,15 +887,16 @@ class IntegrationController {
 
         job_result.results = []
 
-        def valid = Package.validateDTO(json.packageHeader)
+        Package.withNewSession {
+          def user = User.get(request_user.id)
 
-        if ( valid ) {
-          Package.withNewSession {
-            def user = User.get(request_user.id)
+          def pkg_validation = Package.validateDTO(json.packageHeader)
 
+          if ( pkg_validation.valid ) {
             try {
               def the_pkg = Package.upsertDTO(json.packageHeader, user)
               def existing_tipps = []
+              def valid = true
               Boolean curated_pkg = false;
               def is_curator = null;
               if (the_pkg) {
@@ -1005,8 +1006,7 @@ class IntegrationController {
                         log.warn("No platform arising from ${tipp.platform}");
                       }
                     }
-        //
-        //            def pkg = the_pkg.id != null ? Package.get(the_pkg.id) : null
+
                     if ( ( tipp.package == null ) && ( the_pkg.id ) ) {
                       tipp.package = [ internalId: the_pkg.id ]
                     }
@@ -1030,7 +1030,6 @@ class IntegrationController {
                   return job_result
                 }
 
-        //        cleanUpGorm()
 
                 int tippctr=0;
                 if ( valid ) {
@@ -1201,15 +1200,16 @@ class IntegrationController {
               job_result.result = "ERROR"
               job_result.message = "Package referencing failed with exception!"
               job_result.code = 500
-              errors.add([code:500, message: "There was an exception while trying to referencing the Package", data: json.packageHeader])
+              errors.add([code: 500, message: "There was an exception while trying to referencing the Package", data: json.packageHeader])
             }
             cleanUpGorm()
           }
-        }
-        else {
-          log.debug("Package validation failed!")
-          job_result.result = 'ERROR'
-          job_result.message = "Package validation failed!"
+          else {
+            log.debug("Package validation failed!")
+            job_result.result = 'ERROR'
+            errors.add([message: "Unable to validate Package info", baddata: json.packageHeader, errors: pkg_validation.errors])
+            job_result.message = "Package validation failed!"
+          }
         }
 
         job.message(job_result.message.toString())
@@ -1498,6 +1498,10 @@ class IntegrationController {
                 case "database":
                   title_class_name = "org.gokb.cred.DatabaseInstance"
                   break;
+                case "Other":
+                case "other":
+                  title_class_name = "org.gokb.cred.OtherInstance"
+                  break;
                 default:
                   log.warn("Missing type for title!")
                   break;
@@ -1514,7 +1518,7 @@ class IntegrationController {
             }
 
             try {
-              def title = titleLookupService.find(
+              def title = titleLookupService.findOrCreate(
                 titleObj.name,
                 titleObj.publisher,
                 titleObj.identifiers,
@@ -1522,7 +1526,7 @@ class IntegrationController {
                 null,
                 title_class_name,
                 titleObj.uuid
-              );  // project
+              )
 
               if ( title && !title.hasErrors() ) {
 
@@ -1584,7 +1588,7 @@ class IntegrationController {
                         }
                         else {
                           log.debug("Looking up connected title ${fhe} as participant")
-                          p = titleLookupService.find(
+                          p = titleLookupService.findOrCreate(
                             fhe.title,
                             null,
                             fhe.identifiers,
@@ -1618,7 +1622,7 @@ class IntegrationController {
                         }
                         else {
                           log.debug("Looking up connected title ${fhe} as participant")
-                          p = titleLookupService.find(
+                          p = titleLookupService.findOrCreate(
                             fhe.title,
                             null,
                             fhe.identifiers,
@@ -1726,7 +1730,7 @@ class IntegrationController {
                 addPublisherHistory(title, titleObj.publisher_history)
 
                 if (!result.message) {
-                  result.message = "Created/looked up title ${title.id}"
+                  result.message = "Created/Looked up title ${title.id}"
                 }
                 result.cls = title.class.name
                 result.titleId = title.id
@@ -1747,10 +1751,6 @@ class IntegrationController {
                 else {
                   result.message = "Cross Reference of title ${titleObj.name} failed";
                 }
-                // applicationEventService.publishApplicationEvent('CriticalSystemMessages', 'ERROR', [description:"Cross Reference Title failed :${titleObj}"])
-        //         event ( topic:'IntegrationDataError', data:[description:"Cross Reference Title failed :${titleObj}"], params:[:]) {
-        //               // Event callback closure
-        //         }
               }
               else {
                 result.result="ERROR"

--- a/server/gokbg3/grails-app/controllers/org/gokb/rest/OrgController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/rest/OrgController.groovy
@@ -27,6 +27,7 @@ class OrgController {
   def restMappingService
   def componentLookupService
   def componentUpdateService
+  def orgService
 
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
   def index() {
@@ -106,19 +107,35 @@ class OrgController {
     def user = User.get(springSecurityService.principal.id)
 
     if (reqBody) {
-      Org obj = Org.upsertDTO(reqBody, user)
+      def obj = null
+      def lookup_result = orgService.restLookup(reqBody)
 
+      if (lookup_result.to_create) {
+        def normname = Org.generateNormname(reqBody.name)
+        obj = new Org(name: reqBody.name, normname: normname).save(flush:true)
+        log.debug("New Object ${obj}")
+      }
+      else {
+        lookup_result.matches.each { id, errs ->
+          errs.each { e ->
+            if (!errors[e.field])
+              errors[e.field] = []
 
-      if (!obj) {
+            errors[e.field] << [message: e.message, baddata: e.value, matches: id]
+          }
+        }
+      }
+
+      if (lookup_result.to_create && !obj) {
         log.debug("Could not upsert object!")
         errors.object = [[badData: reqBody, message:"Unable to save object!"]]
       }
-      else if (obj.hasErrors()) {
+      else if (obj?.hasErrors()) {
         log.debug("Object has errors!")
         errors = messageService.processValidationErrors(obj.errors, request.locale)
         log.debug("${errors}")
       }
-      else {
+      else if (obj) {
         def jsonMap = obj.jsonMapping
 
         log.debug("Updating ${obj}")
@@ -128,6 +145,13 @@ class OrgController {
           if(errors.size() == 0) {
             log.debug("No errors.. saving")
             obj.save(flush:true)
+
+            if (reqBody.variantNames) {
+              obj = restMappingService.updateVariantNames(obj, reqBody.variantNames)
+            }
+
+            errors = updateCombos(obj, reqBody)
+
             result = restMappingService.mapObjectToJson(obj, params, user)
           }
           else {
@@ -220,15 +244,19 @@ class OrgController {
     render result as JSON
   }
 
-  private void updateCombos(obj, reqBody) {
+  private def updateCombos(obj, reqBody, boolean remove = true) {
     log.debug("Updating package combos ..")
+    def errors = [:]
 
     if (reqBody.ids || reqBody.identifiers) {
       def idmap = reqBody.ids ?: reqBody.identifiers
-      restMappingService.updateIdentifiers(obj, idmap)
+      def id_errors = restMappingService.updateIdentifiers(obj, idmap)
+
+      if (id_errors.size > 0)
+        errors['ids'] = id_errors
     }
 
-    if (reqBody.providedPlatforms || reqBody.platforms) {
+    if (reqBody.providedPlatforms) {
       def plt_list = reqBody.providedPlatforms ?: reqBody.platforms
       Set new_plts = []
 
@@ -238,27 +266,26 @@ class OrgController {
         if (plt instanceof String) {
           plt_obj = Platform.findByNameIlike(plt)
         }
-        else {
+        else if (obj instanceof Integer){
           plt_obj = Platform.get(plt)
         }
 
-        if (pub_obj) {
+        else if (obj instanceof Map && obj.id) {
+          plt_obj = Platform.get(plt.id)
+        }
+
+        if (plt_obj) {
           new_plts << plt_obj
         }
         else {
-          obj.errors.reject(
-            'component.addToList.denied.label',
-            ['providedPlatforms'] as Object[],
-            '[Could not process list of items for property {0}]'
-          )
-          obj.errors.rejectValue(
-            'providedPlatforms',
-            'component.addToList.denied.label'
-          )
+          if (!errors.providedPlatforms) {
+            errors.providedPlatforms = []
+          }
+          errors.providedPlatforms << [message: "Unable to lookup platform!", baddata: plt]
         }
       }
 
-      if (!obj.hasErrors()) {
+      if (!obj.hasErrors() || errors.size() > 0) {
         new_plts.each { c ->
           if (!obj.providedPlatforms.contains(c)) {
             log.debug("Adding new platform ${c}..")
@@ -268,7 +295,10 @@ class OrgController {
             log.debug("Existing platform ${c}..")
           }
         }
-        obj.providedPlatforms.retainAll(new_plts)
+
+        if (remove) {
+          obj.providedPlatforms.retainAll(new_plts)
+        }
       }
       log.debug("New cgs: ${obj.providedPlatforms}")
     }
@@ -288,7 +318,7 @@ class OrgController {
     }
 
     if ( obj && obj.isDeletable() ) {
-      def curator = KBComponent.has(obj, 'curatoryGroups') ? user.curatoryGroups?.id.intersect(pkg.curatoryGroups?.id) : true
+      def curator = KBComponent.has(obj, 'curatoryGroups') ? user.curatoryGroups?.id.intersect(obj.curatoryGroups?.id) : true
 
       if ( curator || user.isAdmin() ) {
         obj.deleteSoft()

--- a/server/gokbg3/grails-app/controllers/org/gokb/rest/PackageController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/rest/PackageController.groovy
@@ -25,6 +25,7 @@ class PackageController {
   def ESSearchService
   def messageService
   def restMappingService
+  def packageService
   def componentLookupService
 
   @Secured(['ROLE_USER', 'IS_AUTHENTICATED_FULLY'])
@@ -109,55 +110,93 @@ class PackageController {
 
     if (reqBody) {
       log.debug("Save package ${reqBody}")
-      def obj = Package.upsertDTO(reqBody, user)
+      def pkg_validation = Package.validateDTO(reqBody)
+      def obj = null
 
-      if (!obj) {
-        log.debug("Could not upsert object!")
-        errors.object = [[badData: reqBody, message:"Unable to save object!"]]
-      }
-      else if (obj.hasErrors()) {
-        log.debug("Object has errors!")
-        errors << messageService.processValidationErrors(obj.errors, request.locale)
-        log.debug("${errors}")
-      }
-      else {
-        def jsonMap = obj.jsonMapping
+      if (pkg_validation.valid) {
+        def lookup_result = packageService.restLookup(reqBody)
 
-        jsonMap.ignore = [
-          'lastProject',
-          'status'
-        ]
+        if (lookup_result.to_create) {
+          def normname = Package.generateNormname(reqBody.name)
+          obj = new Package(name: reqBody.name, normname: normname).save(flush:true)
+          log.debug("New Object ${obj}")
+        }
+        else {
+          lookup_result.matches.each { id, errs ->
+            errs.each { e ->
+              if (!errors[e.field])
+                errors[e.field] = []
 
-        jsonMap.immutable = [
-          'userListVerifier',
-          'listVerifiedDate',
-          'listStatus'
-        ]
+              errors[e.field] << [message: e.message, baddata: e.value, matches: id]
+            }
+          }
+        }
 
-        log.debug("Updating ${obj}")
-        obj = restMappingService.updateObject(obj, jsonMap, reqBody)
+        if (lookup_result.to_create && !obj) {
+          log.debug("Could not upsert object!")
+          errors.object = [[baddata: reqBody, message:"Unable to save object!"]]
+        }
+        else if (obj?.hasErrors()) {
+          log.debug("Object has errors!")
+          errors << messageService.processValidationErrors(obj.errors, request.locale)
+        }
+        else if (obj) {
+          def jsonMap = obj.jsonMapping
 
-        errors << updateCombos(obj, reqBody)
+          jsonMap.ignore = [
+            'lastProject',
+            'status'
+          ]
 
-        log.debug("Errors: ${obj.errors}")
+          jsonMap.immutable = [
+            'userListVerifier',
+            'listVerifiedDate',
+            'listStatus'
+          ]
 
-        if( obj.validate() ) {
-          if (errors.size() == 0) {
-            log.debug("No errors.. saving")
-            obj.save(flush:true)
-            result = restMappingService.mapObjectToJson(obj, params, user)
+          log.debug("Updating ${obj}")
+          obj = restMappingService.updateObject(obj, jsonMap, reqBody)
+
+          if( obj.validate() ) {
+            if (errors.size() == 0) {
+              log.debug("No errors.. saving")
+              obj.save()
+
+              if (reqBody.variantNames) {
+                obj = restMappingService.updateVariantNames(obj, reqBody.variantNames)
+              }
+
+              errors << updateCombos(obj, reqBody)
+
+              if (errors.size() == 0) {
+                log.debug("No errors: ${errors}")
+                obj.save(flush:true)
+                result = restMappingService.mapObjectToJson(obj, params, user)
+              }
+              else {
+                result.result = 'ERROR'
+                log.debug("There were errors setting combo props!")
+                obj.discard()
+                result.error = errors
+              }
+            }
+            else {
+              result.result = 'ERROR'
+              obj.discard()
+              result.message = message(code:"default.create.errors.message")
+              response.setStatus(400)
+            }
           }
           else {
             result.result = 'ERROR'
-            result.message = message(code:"default.create.errors.message")
+            obj.discard()
             response.setStatus(400)
+            errors << messageService.processValidationErrors(obj.errors, request.locale)
           }
         }
-        else {
-          result.result = 'ERROR'
-          response.setStatus(400)
-          errors << messageService.processValidationErrors(obj.errors, request.locale)
-        }
+      }
+      else {
+        errors << pkg_validation.errors
       }
     }
     else {
@@ -165,9 +204,13 @@ class PackageController {
       errors.object = [[baddata: reqBody, message:"Unable to save package!"]]
     }
 
-    if (errors) {
+    if (errors.size() > 0) {
       result.result = 'ERROR'
       result.errors = errors
+
+      if (response.status == 200) {
+        response.setStatus(400)
+      }
     }
 
     render result as JSON
@@ -252,13 +295,25 @@ class PackageController {
     render result as JSON
   }
 
-  private def updateCombos(obj, reqBody) {
+  private def updateCombos(obj, reqBody, boolean remove = true) {
     log.debug("Updating package combos ..")
     def errors = [:]
 
     if (reqBody.ids || reqBody.identifiers) {
-      def idmap = reqBody.ids ?: reqBody.identifiers
-      restMappingService.updateIdentifiers(obj, idmap)
+      def ids = reqBody.ids ?: reqBody.identifiers
+      def id_errors = restMappingService.updateIdentifiers(obj, ids, remove)
+
+      if (id_errors.size > 0) {
+        errors['ids'] = id_errors
+      }
+    }
+
+    if (reqBody.curatoryGroups) {
+      def cg_errors = restMappingService.updateCuratoryGroups(obj, reqBody.curatoryGroups, remove)
+
+      if (cg_errors.size() > 0) {
+        errors['curatoryGroups'] = cg_errors
+      }
     }
 
     if (reqBody.provider) {
@@ -317,7 +372,7 @@ class PackageController {
 
           if (upserted_tipp) {
             if (errors.size() == 0) {
-              upserted_tipp = upserted_tipp?.merge(flush: true)
+              upserted_tipp = upserted_tipp?.save(flush: true)
             }
           }
           else {
@@ -330,7 +385,6 @@ class PackageController {
         }
       }
     }
-    log.debug("After update: ${obj.errors}")
     errors
   }
 

--- a/server/gokbg3/grails-app/controllers/org/gokb/rest/TitleController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/rest/TitleController.groovy
@@ -141,8 +141,10 @@ class TitleController {
     def reqBody = request.JSON
     def errors = [:]
     Class type = setType(params)
+    def obj = null
     def user = User.get(springSecurityService.principal.id)
     def ids = reqBody.ids ?: reqBody.identifiers
+    def base = grailsApplication.config.serverURL + "/rest"
 
     def publisher_name = null
 
@@ -159,39 +161,76 @@ class TitleController {
     }
 
     if ( reqBody?.name?.trim() && type && type != TitleInstance ) {
-      def obj = titleLookupService.find(
-        reqBody.name,
-        publisher_name,
-        ids,
-        user,
-        null,
-        type.name
-      )
+      try {
+        def title_lookup = titleLookupService.find(
+          reqBody.name,
+          publisher_name,
+          ids,
+          type.name
+        )
 
-      if (!obj) {
-        log.debug("Could not upsert object!")
-        errors.object = [[badData: reqBody, message:"Unable to save object!"]]
-      }
-      else if (obj.hasErrors()) {
-        log.debug("Object has errors!")
-        errors = messageService.processValidationErrors(obj.errors, request.locale)
-      }
-      else {
-        obj = restMappingService.updateObject(obj, obj.jsonMapping, reqBody)
+        if (title_lookup.to_create) {
+          obj = type.newInstance()
+          obj.name = reqBody.name.trim()
 
-        if ( obj.validate() ) {
-          if (errors.size() == 0 ) {
-            obj.save(flush:true)
-            result = restMappingService.mapObjectToJson(obj, params, user)
+          obj = restMappingService.updateObject(obj, obj.jsonMapping, reqBody)
+
+          if ( obj.validate() ) {
+            if (errors.size() == 0 ) {
+              obj.save(flush:true)
+
+              if (title_lookup.matches.size() > 0) {
+                def additionalInfo = [:]
+                def combo_ids = [obj.id]
+
+                additionalInfo.otherComponents = []
+
+                title_lookup.matches.each { tlm ->
+                  additionalInfo.otherComponents.add([oid:"${tlm.object.id}", name:"${tlm.object.name}"])
+                  combo_ids.add(tlm.obect.id)
+                }
+
+                additionalInfo.cstring = combo_ids.sort().join('_')
+
+                ReviewRequest.raise(
+                  obj,
+                  "New TI created.",
+                  "There have been possible conflicts with other existing titles.",
+                  user, 
+                  null,
+                  (additionalInfo as JSON).toString()
+                )
+              }
+
+              if (reqBody.variantNames) {
+                obj = restMappingService.updateVariantNames(obj, reqBody.variantNames)
+              }
+
+              errors << updateCombos(obj, reqBody)
+
+              result = restMappingService.mapObjectToJson(obj, params, user)
+            }
+            else {
+              result.message = message(code: 'default.create.errors.message')
+            }
           }
           else {
-            result.message = message(code: 'default.create.errors.message')
+            result.result = 'ERROR'
+            errors << messageService.processValidationErrors(obj.errors, request.locale)
           }
         }
         else {
-          result.result = 'ERROR'
-          errors.addAll(messageService.processValidationErrors(obj.errors, request.locale))
+          title_lookup.matches.each { tlm ->
+            if (!errors.ids) {
+              errors.ids = []
+            }
+
+            errors.ids << [message:"There has been an identifier conflict with another title!", baddata: reqBody.ids, item: [id: tlm.object.id, name: tlm.object.name, href: (base + "/titles/" + tlm.object.id)]]
+          }
         }
+      }
+      catch (grails.validation.ValidationException ve) {
+        errors.ids = messageService.processValidationErrors(ve.errors, request.locale)
       }
     }
     else if (!type) {
@@ -321,10 +360,14 @@ class TitleController {
         if ( obj.validate() ) {
           log.debug("No errors.. updating combos..")
 
+          if (reqBody.variantNames) {
+            obj = restMappingService.updateVariantNames(obj, reqBody.variantNames)
+          }
+
           errors << updateCombos(obj, reqBody)
 
           if ( errors.size() == 0 ) {
-            obj = obj.merge(flush:true)
+            obj = obj.save(flush:true)
             result = restMappingService.mapObjectToJson(obj, params, user)
           }
           else {
@@ -357,147 +400,25 @@ class TitleController {
     render result as JSON
   }
 
-  private def updateCombos(obj, reqBody) {
+  @Transactional
+  private def updateCombos(obj, reqBody, boolean remove = true) {
     log.debug("Updating title combos ..")
     def errors = [:]
 
-    def combo_active = RefdataCategory.lookup(Combo.RD_STATUS, Combo.STATUS_ACTIVE)
-    def combo_deleted = RefdataCategory.lookup(Combo.RD_STATUS, Combo.STATUS_DELETED)
-    def combo_id_type = RefdataCategory.lookup(Combo.RD_TYPE, "KBComponent.Ids")
-    def combo_expired = RefdataCategory.lookup(Combo.RD_STATUS, Combo.STATUS_EXPIRED)
-
     if (reqBody.ids || reqBody.identifiers) {
-      def id_combos = []
-      id_combos.addAll( obj.getCombosByPropertyName('ids') )
-      def new_ids = restMappingService.updateIdentifiers(obj, reqBody.ids ?: reqBody.identifiers)
+      def id_map = reqBody.ids ?: reqBody.identifiers
+      def id_errors = restMappingService.updateIdentifiers(obj, id_map, remove)
 
-      new_ids.each { i ->
-
-        def dupe = Combo.executeQuery("from Combo where type = ? and fromComponent = ? and toComponent = ?",[combo_id_type, obj, i])
-
-        if (dupe.size() == 0) {
-          log.debug("No combo found, adding ID ..")
-          def new_combo = new Combo(fromComponent: obj, toComponent: i, status: combo_active, type: combo_id_type).save(flush:true)
-        }
-        else if (dupe.size() == 1 ) {
-          if (dupe[0].status == combo_deleted) {
-            log.debug("Matched ID combo was marked as deleted!")
-          }
-          else {
-            log.debug("Not adding duplicate ..")
-          }
-        }
-        else {
-          if (!errors.ids) {
-            errors.ids = []
-          }
-
-          errors.ids << [message: "There seem to be duplicate links for an identifier against this title!", baddata: i]
-          log.error("Multiple ID combos for ${obj} -- ${i}!")
-        }
-      }
-
-      Iterator items = id_combos.iterator();
-      Object element;
-      while (items.hasNext()) {
-        element = items.next();
-        if (!new_ids.contains(element.toComponent)) {
-          // Remove.
-          element.status = combo_deleted
-        }
+      if (id_errors.size() > 0) {
+        errors.ids = id_errors
       }
     }
 
     if (reqBody.publisher) {
-      def publisher_combos = []
-      publisher_combos.addAll( obj.getCombosByPropertyName('publisher') )
-      String propName = obj.isComboReverse('publisher') ? 'fromComponent' : 'toComponent'
-      String tiPropName = obj.isComboReverse('publisher') ? 'toComponent' : 'fromComponent'
-      def pubs_to_add = []
+      def pub_errors = restMappingService.updatePublisher(obj, reqBody.publisher, remove)
 
-      if (reqBody.publisher instanceof Collection) {
-        reqBody.publisher.each { pub ->
-          if (!pubs_to_add.collect { it.id == pub}) {
-            pubs_to_add << Org.get(pub)
-          }
-          else {
-            log.warn("Duplicate for incoming publisher ${pub}!")
-          }
-        }
-      }
-      else {
-          if (!pubs_to_add.collect { it.id == reqBody.publisher}) {
-            pubs_to_add << Org.get(reqBody.publisher)
-          }
-          else {
-            log.warn("Duplicate for incoming publisher ${reqBody.publisher}!")
-          }
-      }
-
-      pubs_to_add.each { publisher ->
-        boolean found = false
-        for ( int i=0; !found && i<publisher_combos.size(); i++) {
-          Combo pc = publisher_combos[i]
-          def idMatch = pc."${propName}".id == publisher.id
-
-          if (idMatch) {
-            found = true
-          }
-        }
-
-        if (!found) {
-
-          log.debug("Adding new combo for publisher ${publisher} (${propName}) to title ${obj} (${tiPropName})")
-
-          RefdataValue type = RefdataCategory.lookupOrCreate(Combo.RD_TYPE, obj.getComboTypeValue('publisher'))
-
-          def combo = null
-
-          if (propName == "toComponent") {
-            combo = new Combo(
-              type            : (type),
-              status          : combo_active,
-              toComponent     : publisher,
-              fromComponent   : obj
-            )
-          } else {
-            combo = new Combo(
-              type            : (type),
-              status          : combo_active,
-              fromComponent   : publisher,
-              toComponent     : obj
-            )
-          }
-
-          if (combo) {
-            combo.save(flush:true, failOnError:true)
-
-            log.debug "Added publisher ${publisher.name} for '${obj.name}'" +
-              (combo.startDate ? ' from ' + combo.startDate : '') +
-              (combo.endDate ? ' to ' + combo.endDate : '')
-          } else {
-            log.error("Could not create publisher Combo..")
-            if (!errors.publisher) {
-              errors.publisher = []
-            }
-
-            errors.publisher << [message: "Unable to add publisher ${publisher.name} to title!", baddata: publisher.id]
-          }
-
-        } else {
-          log.debug "Publisher ${publisher.name} already set against '${obj.name}'"
-        }
-      }
-
-      Iterator items = publisher_combos.iterator();
-      Object element;
-      while (items.hasNext()) {
-        element = items.next();
-        if (!pubs_to_add.contains(element.toComponent) && !pubs_to_add.contains(element.fromComponent)) {
-          // Remove.
-          element.delete()
-        }
-      }
+      if (pub_errors.size() > 0)
+        errors.publisher = pub_errors
     }
 
     errors

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Combo.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Combo.groovy
@@ -1,6 +1,7 @@
 package org.gokb.cred
 import grails.plugins.orm.auditable.Auditable
 import javax.persistence.Transient
+import org.gokb.DomainClassExtender
 
 /**
  * @author sosguthorpe
@@ -65,15 +66,21 @@ class Combo implements Auditable {
   String getLogEntityId() {
       "${this.class.name}:${id}"
   }
+
+  def afterInsert() {
+    if (!status) {
+      status = DomainClassExtender.getComboStatusActive()
+    }
+  }
   
   public Date expire (Date endDate = null, boolean replaced = false) {
 
-	if (endDate == null) endDate = new Date ()
+    if (endDate == null) endDate = new Date ()
 
-	// Expire this combo...
-	setStatus (RefdataCategory.lookupOrCreate(Combo.RD_STATUS, (replaced ? Combo.STATUS_SUPERSEDED : Combo.STATUS_EXPIRED)))
-	setEndDate(endDate)
-	save()
-	endDate
+    // Expire this combo...
+    setStatus (RefdataCategory.lookupOrCreate(Combo.RD_STATUS, (replaced ? Combo.STATUS_SUPERSEDED : Combo.STATUS_EXPIRED)))
+    setEndDate(endDate)
+    save()
+    endDate
   }
 }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/KBComponent.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/KBComponent.groovy
@@ -1200,7 +1200,7 @@ where cp.owner = :c
         // Make sure not already a variant name
         def existing_variants = KBComponentVariantName.findAllByNormVariantName(normname)
         if ( existing_variants.size() == 0 ) {
-          result = new KBComponentVariantName( owner:this, variantName:name ).save()
+          result = new KBComponentVariantName( owner:this, variantName:name ).save(flush:true)
         }
         else {
           log.debug("Unable to add ${name} as an alternate name to ${id} - it's already an alternate name....");

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Org.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Org.groovy
@@ -81,8 +81,8 @@ class Org extends KBComponent {
       if (obj.hasChanged('name')) {
         if (val && val.trim()) {
           def status_deleted = RefdataCategory.lookup('KBComponent.Status', 'Deleted')
-          def dupes = Org.findByNameIlikeAndStatusNotEqual(val, status_deleted);
-          if (dupes && dupes != obj) {
+          def dupes = Org.findAllByNameIlikeAndStatusNotEqual(val, status_deleted);
+          if (dupes?.size() > 0 && dupes.any {it != obj}) {
             return ['notUnique']
           }
         }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Package.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Package.groovy
@@ -99,8 +99,9 @@ class Package extends KBComponent {
       if (obj.hasChanged('name')) {
         if (val && val.trim()) {
           def status_deleted = RefdataCategory.lookup('KBComponent.Status', 'Deleted')
-          def dupes = Package.findByNameIlikeAndStatusNotEqual(val, status_deleted);
-          if (dupes && dupes != obj) {
+          def dupes = Package.findAllByNameIlikeAndStatusNotEqual(val, status_deleted);
+
+          if (dupes?.size() > 0 && dupes.any { it != obj }) {
             return ['notUnique']
           }
         } else {
@@ -604,12 +605,96 @@ select tipp.id,
    * Definitive rules for a valid package header
    */
   @Transient
-  public static boolean validateDTO(packageHeaderDTO) {
-    def result = true;
-    result &= (packageHeaderDTO != null)
-    result &= (packageHeaderDTO.name != null)
-    result &= (packageHeaderDTO.name.trim().length() > 0)
-    result;
+  public static def validateDTO(packageHeaderDTO) {
+    def result = [valid: true, errors:[:]]
+
+    if (!packageHeaderDTO.name?.trim()) {
+      result.valid = false
+      result.errors.name = [[message: "Missing package name!", baddata: packageHeaderDTO.name]]
+    }
+
+    def ids_list = packageHeaderDTO.identifiers ?: packageHeaderDTO.ids
+    def id_errors = []
+
+    ids_list?.each { idobj ->
+      def id_def = [:]
+      def ns_obj = null
+
+      if (idobj instanceof Map) {
+        def id_ns = idobj.type ?: (idobj.namespace ?: null)
+
+        id_def.value = idobj.value
+
+        if (id_ns instanceof String) {
+          log.debug("Default namespace handling for ${id_ns}..")
+          ns_obj = IdentifierNamespace.findByValueIlike(id_ns)
+        }
+        else if (id_ns) {
+          log.debug("Handling namespace def ${id_ns}")
+          ns_obj = IdentifierNamespace.get(id_ns)
+        }
+
+        if (!ns_obj) {
+          id_errors.add([message: message(code: 'default.not.found.message', args: ["Namespace", id_ns], default:"unable to lookup identifier namespace ${id_ns}!")])
+        }
+        else {
+          id_def.type = ns_obj.value
+        }
+      }
+      else if (idobj instanceof Integer){
+        Identifier the_id = Identifier.get(id_inc)
+
+        if (!the_id) {
+          id_errors.add([message:"Unable to lookup identifier object by ID!", baddata: idobj])
+          result.valid = false
+        }
+      }
+      else {
+        log.warn("Missing information in id object ${idobj}")
+        id_errors.add([message:"Missing information for identifier object!", baddata: idobj])
+        result.valid = false
+      }
+
+      if (ns_obj && id_def.size() > 0) {
+        if (!Identifier.findByNamespaceAndNormname(ns_obj, Identifier.normalizeIdentifier(id_def.value))) {
+          if ( ns_obj.pattern && !(id_def.value ==~ ns_obj.pattern) ) {
+            log.warn("Validation for ${id_def.type}:${id_def.value} failed!")
+            id_errors.add([message:"Validation for identifier ${id_def.type}:${id_def.value} failed!", baddata: idobj])
+            result.valid = false
+          }
+          else {
+            log.debug("New identifier ..")
+          }
+        }
+        else {
+          log.debug("Found existing identifier ..")
+        }
+      }
+    }
+
+    if (id_errors.size() > 0) {
+      result.errors.ids = id_errors
+    }
+
+    if (packageHeaderDTO.provider && packageHeaderDTO.provider instanceof Integer) {
+      def prov = Org.get(packageHeaderDTO.provider)
+
+      if (!prov) {
+        result.errors.provider = [[message: "Unable to find provider via ID", baddata: packageHeaderDTO.provider]]
+        result.valid =false
+      }
+    }
+
+    if (packageHeaderDTO.nominalPlatform && packageHeaderDTO.nominalPlatform instanceof Integer) {
+      def prov = Platform.get(packageHeaderDTO.nominalPlatform)
+
+      if (!prov) {
+        result.errors.nominalPlatform = [[message: "Unable to find platform via ID", baddata: packageHeaderDTO.nominalPlatform]]
+        result.valid = false
+      }
+    }
+
+    result
   }
 
   /**
@@ -880,9 +965,20 @@ select tipp.id,
 
     // Source
 
-    if (packageHeaderDTO.source?.url) {
-      def src = Source.findByUrl(packageHeaderDTO.source.url)
-      if (src) {
+    if (packageHeaderDTO.source) {
+      def src = null
+
+      if (packageHeaderDTO.source instanceof Integer) {
+        src = Source.get(packageHeaderDTO.source)
+      }
+      else if (packageHeaderDTO.source.id) {
+        src = Source.get(packageHeaderDTO.source.id)
+      }
+      else if (packageHeaderDTO.source.url) {
+        src = Source.findByUrl(packageHeaderDTO.source.url)
+      }
+
+      if (src && result.source != src) {
         result.source = src
         changed = true
       }
@@ -899,10 +995,27 @@ select tipp.id,
     // CuratoryGroups
 
     packageHeaderDTO.curatoryGroups?.each {
+      def cg = null
+      def cgname = null
 
-      String normname = CuratoryGroup.generateNormname(it)
+      if (it instanceof Integer) {
+        cg = CuratoryGroup.get(it)
+      }
+      else if (it instanceof String) {
+        String normname = CuratoryGroup.generateNormname(it)
+        cgname = it
 
-      def cg = CuratoryGroup.findByNormname(normname)
+        cg = CuratoryGroup.findByNormname(normname)
+      }
+      else if (it.id){
+        cg = CuratoryGroup.get(it.id)
+      }
+      else if (it.name) {
+        String normname = CuratoryGroup.generateNormname(it.name)
+        cgname = it.name
+
+        cg = CuratoryGroup.findByNormname(normname)
+      }
 
       if (cg) {
         if (result.curatoryGroups.find { it.name == cg.name }) {
@@ -911,14 +1024,14 @@ select tipp.id,
           result.curatoryGroups.add(cg)
           changed = true;
         }
-      } else {
-        def new_cg = new CuratoryGroup(name: it).save(flush: true, failOnError: true)
+      } else if (cgname) {
+        def new_cg = new CuratoryGroup(name: cgname).save(flush: true, failOnError: true)
         result.curatoryGroups.add(new_cg)
         changed = true
       }
     }
 
-    result.save(flush: true, failOnError: true);
+    result.save(flush:true)
 
 
     result

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Platform.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Platform.groovy
@@ -60,8 +60,8 @@ class Platform extends KBComponent {
       if (obj.hasChanged('name')) {
         if (val && val.trim()) {
           def status_deleted = RefdataCategory.lookup('KBComponent.Status', 'Deleted')
-          def dupes = Platform.findByNameIlikeAndStatusNotEqual(val, status_deleted);
-          if (dupes && dupes != obj) {
+          def dupes = Platform.findAllByNameIlikeAndStatusNotEqual(val, status_deleted);
+          if (dupes?.size() > 0 && dupes.any {it != obj}) {
             return ['notUnique']
           }
         } else {

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Source.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Source.groovy
@@ -39,8 +39,9 @@ class Source extends KBComponent {
       if (obj.hasChanged('name')) {
         if (val && val.trim()) {
           def status_deleted = RefdataCategory.lookup('KBComponent.Status', 'Deleted')
-          def dupes = Source.findByNameIlikeAndStatusNotEqual(val, status_deleted);
-          if (dupes && dupes != obj) {
+          def dupes = Source.findAllByNameIlikeAndStatusNotEqual(val, status_deleted);
+          
+          if (dupes.size() > 0 && dupes.any {it != obj}) {
             return ['notUnique']
           }
         }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstance.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstance.groovy
@@ -612,7 +612,7 @@ class TitleInstance extends KBComponent {
       result.errors.name =  [[message: "Missing title name!", baddata: titleDTO.name]]
       return result
     }
-    
+
     def ids_list = titleDTO.identifiers ?: titleDTO.ids
 
     LocalDateTime startDate = GOKbTextUtils.completeDateString(titleDTO.publishedFrom)
@@ -636,28 +636,58 @@ class TitleInstance extends KBComponent {
     def id_errors = []
 
     ids_list?.each { idobj ->
-      if (idobj.type && idobj.value) {
-        def found_ns = IdentifierNamespace.findByValue(idobj.type.toLowerCase())
-        def final_val = idobj.value
+      def id_def = [:]
+      def ns_obj = null
 
-        if (found_ns) {
-          if (found_ns.family == 'isxn') {
-            final_val = final_val.replaceAll("x","X")
-          }
+      if (idobj instanceof Map) {
+        def id_ns = idobj.type ?: (idobj.namespace ?: null)
 
-          if (!Identifier.findByNamespaceAndNormname(found_ns, Identifier.normalizeIdentifier(final_val))) {
-            if ( found_ns.pattern && !(final_val ==~ found_ns.pattern) ) {
-              log.warn("Validation for ${found_ns.value}:${final_val} failed!")
-              id_errors.add([message:"Validation for identifier ${found_ns.value}:${final_val} failed!", baddata: idobj])
-              result.valid = false
-            }
-          }
+        id_def.value = idobj.value
+
+        if (id_ns instanceof String) {
+          log.debug("Default namespace handling for ${id_ns}..")
+          ns_obj = IdentifierNamespace.findByValueIlike(id_ns)
+        }
+        else if (id_ns) {
+          log.debug("Handling namespace def ${id_ns}")
+          ns_obj = IdentifierNamespace.get(id_ns)
+        }
+
+        if (!ns_obj) {
+          id_errors.add([message: "Unable to lookup identifier namespace ${id_ns}!", baddata: id_ns, code: 404])
+        }
+        else {
+          id_def.type = ns_obj.value
+        }
+      }
+      else if (idobj instanceof Integer){
+        Identifier the_id = Identifier.get(id_inc)
+
+        if (!the_id) {
+          id_errors.add([message:"Unable to lookup identifier object by ID!", baddata: idobj])
+          result.valid = false
         }
       }
       else {
         log.warn("Missing information in id object ${idobj}")
         id_errors.add([message:"Missing information for identifier object!", baddata: idobj])
         result.valid = false
+      }
+
+      if (ns_obj && id_def.size() > 0) {
+        if (!Identifier.findByNamespaceAndNormname(ns_obj, Identifier.normalizeIdentifier(id_def.value))) {
+          if ( ns_obj.pattern && !(id_def.value ==~ ns_obj.pattern) ) {
+            log.warn("Validation for ${id_def.type}:${id_def.value} failed!")
+            id_errors.add([message:"Validation for identifier ${id_def.type}:${id_def.value} failed!", baddata: idobj])
+            result.valid = false
+          }
+          else {
+            log.debug("New identifier ..")
+          }
+        }
+        else {
+          log.debug("Found existing identifier ..")
+        }
       }
     }
 
@@ -696,6 +726,7 @@ class TitleInstance extends KBComponent {
           type = "org.gokb.cred.DatabaseInstance"
           break;
         case "Other":
+        case "other":
           type = "org.gokb.cred.OtherInstance"
           break;
         default:
@@ -705,7 +736,7 @@ class TitleInstance extends KBComponent {
     }
 
     if (type) {
-      result = titleLookupService.find(titleDTO.name,
+      result = titleLookupService.findOrCreate(titleDTO.name,
                                       titleDTO.publisher,
                                       titleDTO.identifiers,
                                       user,
@@ -756,7 +787,7 @@ class TitleInstance extends KBComponent {
   @Override
   @Transient
   def ensureVariantName(String name) {
-
+    def result = null
     if (name.trim().size() != 0) {
 
       // Variant names use different normalisation method.
@@ -765,7 +796,7 @@ class TitleInstance extends KBComponent {
       // not already a name
       // Make sure not already a variant name
       if ( !KBComponentVariantName.findByOwnerAndNormVariantName(this, variant_normname) ) {
-        KBComponentVariantName kvn = new KBComponentVariantName( owner:this, variantName:name ).save()
+        result = new KBComponentVariantName( owner:this, variantName:name ).save(flush:true)
       }
       else {
         log.debug("Unable to add ${name} as an alternate name to ${id} - it's already an alternate name....");
@@ -774,7 +805,7 @@ class TitleInstance extends KBComponent {
     else {
       log.error("No viable variant name supplied!")
     }
-
+    result
   }
 
   def beforeUpdate() {

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePackagePlatform.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePackagePlatform.groovy
@@ -172,7 +172,7 @@ class TitleInstancePackagePlatform extends KBComponent {
     url (nullable:true, blank:true)
   }
 
-  public static final String restPath = "/tipps"
+  public static final String restPath = "/package-titles"
 
   def availableActions() {
     [ [code:'setStatus::Retired', label:'Retire'],
@@ -209,16 +209,15 @@ class TitleInstancePackagePlatform extends KBComponent {
     def result = new TitleInstancePackagePlatform(uuid: tipp_fields.uuid, status: tipp_status, editStatus: tipp_editstatus).save(failOnError: true)
 
     if ( result ) {
-      def combo_status_active = RefdataCategory.lookupOrCreate(Combo.RD_STATUS, Combo.STATUS_ACTIVE)
 
       def pkg_combo_type = RefdataCategory.lookupOrCreate('Combo.Type', 'Package.Tipps')
-      def pkg_combo = new Combo(toComponent:result, fromComponent:tipp_fields.pkg, type:pkg_combo_type, status:combo_status_active).save(flush:true, failOnError:true);
+      def pkg_combo = new Combo(toComponent:result, fromComponent:tipp_fields.pkg, type:pkg_combo_type).save(flush:true, failOnError:true);
 
       def plt_combo_type = RefdataCategory.lookupOrCreate('Combo.Type', 'Platform.HostedTipps')
-      def plt_combo = new Combo(toComponent:result, fromComponent:tipp_fields.hostPlatform, type:plt_combo_type, status:combo_status_active).save(flush:true, failOnError:true);
+      def plt_combo = new Combo(toComponent:result, fromComponent:tipp_fields.hostPlatform, type:plt_combo_type).save(flush:true, failOnError:true);
 
       def ti_combo_type = RefdataCategory.lookupOrCreate('Combo.Type', 'TitleInstance.Tipps')
-      def ti_combo = new Combo(toComponent:result, fromComponent:tipp_fields.title, type:ti_combo_type, status:combo_status_active).save(flush:true, failOnError:true);
+      def ti_combo = new Combo(toComponent:result, fromComponent:tipp_fields.title, type:ti_combo_type).save(flush:true, failOnError:true);
 
       def tipl = TitleInstancePlatform.ensure(tipp_fields.title, tipp_fields.hostPlatform, tipp_fields.url);
     }

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePlatform.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/TitleInstancePlatform.groovy
@@ -61,13 +61,11 @@ class TitleInstancePlatform extends KBComponent {
       if ( r.size() == 0 ) {
         def tipl = new TitleInstancePlatform(url:url).save(flush:true, failOnError:true)
 
-        def combo_status_active = RefdataCategory.lookup(Combo.RD_STATUS, Combo.STATUS_ACTIVE)
-
         def plt_combo_type = RefdataCategory.lookup('Combo.Type', 'Platform.HostedTitles')
-        def plt_combo = new Combo(toComponent:tipl, fromComponent:platform, type:plt_combo_type, status:combo_status_active).save(flush:true, failOnError:true);
+        def plt_combo = new Combo(toComponent:tipl, fromComponent:platform, type:plt_combo_type).save(flush:true, failOnError:true);
 
         def ti_combo_type = RefdataCategory.lookup('Combo.Type', 'TitleInstance.Tipls')
-        def ti_combo = new Combo(toComponent:tipl, fromComponent:title, type:ti_combo_type, status:combo_status_active).save(flush:true, failOnError:true);
+        def ti_combo = new Combo(toComponent:tipl, fromComponent:title, type:ti_combo_type).save(flush:true, failOnError:true);
 
         return tipl
 

--- a/server/gokbg3/grails-app/i18n/messages.properties
+++ b/server/gokbg3/grails-app/i18n/messages.properties
@@ -335,6 +335,7 @@ tipp.title.nullable = No TIPP title provided!
 tipp.pkg.nullable = No TIPP package provided!
 tipp.url.nullable = No TIPP url provided!
 
+identifierNamespace.label = Namespace
 identifierNamespace.value.unique.error=A Namespace with this name already exists!
 
 variantName.label=Variant

--- a/server/gokbg3/grails-app/services/gokbg3/RestMappingService.groovy
+++ b/server/gokbg3/grails-app/services/gokbg3/RestMappingService.groovy
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 import org.gokb.cred.*
-import org.gokb.DomainClassExtender
 import org.gokb.GOKbTextUtils
 import org.grails.datastore.mapping.model.*
 import org.grails.datastore.mapping.model.types.*
@@ -20,6 +19,8 @@ class RestMappingService {
   def genericOIDService
   def classExaminationService
   def componentLookupService
+  def messageSource
+  def messageService
 
   def defaultIgnore = [
     'bucketHash',
@@ -217,7 +218,7 @@ class RestMappingService {
             // Add to collection
             log.debug("Skip generic handling of collections}");
 
-            if (p.name == "variantNames") {
+            if (p.name == "variantNames" && obj.id) {
               updateVariantNames(obj, reqBody.variantNames)
             }
           }
@@ -237,14 +238,6 @@ class RestMappingService {
               break;
           }
         }
-      }
-    }
-
-    if (reqBody.groups || reqBody.curatoryGroups) {
-      if (KBComponent.has(obj, 'curatoryGroups')) {
-
-        def cgs = reqBody.groups ?: reqBody.curatoryGroups
-        updateCuratoryGroups(obj, cgs)
       }
     }
     obj
@@ -321,7 +314,14 @@ class RestMappingService {
           }
         }
       } else {
-        def linkObj = ptype.get(val)
+        def linkObj = null
+
+        if (val instanceof Integer) {
+          linkObj = ptype.get(val)
+        }
+        else if (val instanceof Map) {
+          linkObj = val.id ? ptype.get(val.id) : null
+        }
 
         if (linkObj) {
           obj[prop] = linkObj
@@ -343,15 +343,20 @@ class RestMappingService {
     }
   }
 
-  public def updateIdentifiers(obj, ids) {
+  @Transactional
+  public def updateIdentifiers(obj, ids, boolean remove = true) {
     log.debug("updating ids ${ids}")
-    def combo_deleted = RefdataCategory.lookup(Combo.RD_STATUS, Combo.STATUS_DELETED)
-    def combo_type_id = RefdataCategory.lookup('Combo.Type','KBComponent.Ids')
+    RefdataValue combo_deleted = RefdataCategory.lookup(Combo.RD_STATUS, Combo.STATUS_DELETED)
+    RefdataValue combo_id_type = RefdataCategory.lookup(Combo.RD_TYPE, "KBComponent.Ids")
+    RefdataValue combo_expired = RefdataCategory.lookup(Combo.RD_STATUS, Combo.STATUS_EXPIRED)
+    def id_combos = obj.getCombosByPropertyName('ids')
+    def errors = []
     Set new_ids = []
 
     if (obj && ids instanceof Collection) {
       ids.each { i ->
         Identifier id = null
+        def valid = true
 
         if (i instanceof Integer) {
           id = Identifier.get(i)
@@ -376,87 +381,128 @@ class RestMappingService {
             }
             catch (grails.validation.ValidationException ve) {
               log.debug("Could not create ID ${ns}:${i.value}")
-              obj.errors.reject(
-                'identifier.value.IllegalIDForm',
-                [i.value, ns_val] as Object[],
-                '[Value {0} is not valid for namespace {1}]'
-              )
-              obj.errors.rejectValue(
-                'ids',
-                'identifier.value.IllegalIDForm'
-              )
+
+              errors << messageService.processValidationErrors(ve)
             }
           } else {
-            obj.errors.reject(
-              'identifier.value.IllegalIDForm',
-              [i.value, ns_val] as Object[],
-              '[Value {0} is not valid for namespace {1}]'
-            )
-            obj.errors.rejectValue(
-              'ids',
-              'identifier.value.IllegalIDForm'
-            )
+            errors << [message: message(code:'identifier.value.IllegalIDForm'), baddata: i]
+            valid = false
           }
         }
         else {
+          errors << [message: "Could not identify ID form!", baddata: i]
+          valid = false
           log.error("Could not identify ID form!")
         }
 
-        if ( id && !obj.hasErrors() ) {
+        if (id && !obj.hasErrors() && valid) {
           log.debug("Adding id ${id} to current set")
           new_ids << id
         }
-        else {
+        else if (!id) {
           log.debug("No Identifier found for ID ${i}, or errors on object ..")
+        }
+      }
+
+      if (errors.size() == 0) {
+        new_ids.each { i ->
+
+          def dupe = Combo.executeQuery("from Combo where type = ? and fromComponent = ? and toComponent = ?",[combo_id_type, obj, i])
+
+          if (dupe.size() == 0) {
+            obj.ids.add(i)
+          }
+          else if (dupe.size() == 1 ) {
+            if (dupe[0].status == combo_deleted) {
+              log.debug("Matched ID combo was marked as deleted!")
+            }
+            else {
+              log.debug("Not adding duplicate ..")
+            }
+          }
+          else {
+            if (!errors.ids) {
+              errors.ids = []
+            }
+
+            errors.ids << [message: "There seem to be duplicate links for an identifier against this title!", baddata: i]
+            log.error("Multiple ID combos for ${obj} -- ${i}!")
+          }
+        }
+
+        if (remove) {
+          Iterator items = id_combos.iterator();
+          Object element;
+          while (items.hasNext()) {
+            element = items.next();
+            if (!new_ids.contains(element.toComponent)) {
+              // Remove.
+              element.status = combo_deleted
+            }
+          }
         }
       }
     }
     else {
       log.error("Object ${obj} not found or illegal id format")
+      errors << [message: "Expected an Array to process!", baddata: ids]
     }
-    new_ids
+
+    errors
   }
 
-  public def updateCuratoryGroups(obj, cgs) {
+  @Transactional
+  public def updateCuratoryGroups(obj, cgs, boolean remove = true) {
     log.debug("Update curatory Groups ${cgs}")
     Set new_cgs = []
+    def errors = []
+    def current_cgs = obj.getCombosByPropertyName('curatoryGroups')
+    RefdataValue combo_type = RefdataCategory.lookup('Combo.Type', obj.getComboTypeValue('curatoryGroups'))
 
     cgs.each { cg ->
       def cg_obj = null
 
       if (cg instanceof String) {
         cg_obj = CuratoryGroup.findByNameIlike(cg)
-      } else {
+      } else if (cg instanceof Integer){
         cg_obj = CuratoryGroup.get(cg)
       }
 
       if (cg_obj) {
         new_cgs << cg_obj
       } else {
-        obj.errors.reject(
-          'component.addToList.denied.label',
-          ['curatoryGroups'] as Object[],
-          '[Could not process list of items for property {0}]'
-        )
+        errors << [message: "Unable to lookup curatory group!", baddata: cg]
       }
     }
 
-    if (!obj.hasErrors()) {
+    if (errors.size() == 0) {
       new_cgs.each { c ->
         if (!obj.curatoryGroups.contains(c)) {
-          log.debug("Adding new cg ${c}..")
           obj.curatoryGroups.add(c)
         } else {
           log.debug("Existing cg ${c}..")
         }
       }
-      obj.curatoryGroups.retainAll(new_cgs)
+      
+      if (remove) {
+        Iterator items = current_cgs.iterator();
+        Object element;
+        while (items.hasNext()) {
+          element = items.next();
+          if (!new_cgs.contains(element.toComponent)) {
+            // Remove.
+            element.delete()
+          }
+        }
+      }
     }
     log.debug("New cgs: ${obj.curatoryGroups}")
-    obj
+    errors
   }
 
-  public def updateVariantNames(obj, vals) {
+  @Transactional
+  public def updateVariantNames(obj, vals, boolean remove = true) {
+    log.debug("Update Variants ..")
     def remaining = []
     def notFound = []
 
@@ -471,8 +517,28 @@ class RestMappingService {
             if (dupes) {
               log.debug("Not adding duplicate variant")
             } else {
-              obj.addToVariantNames(variantName: it)
+              newVariant = obj.ensureVariantName(it)
+
+              if (newVariant) {
+                log.debug("Added variant ${newVariant}")
+                remaining << newVariant
+              }
+              else {
+                log.debug("Could not add variant ${it}!")
+                obj.errors.reject(
+                  'component.addToList.denied.label',
+                  ['variantNames'] as Object[],
+                  '[Could not process list of items for property {0}]'
+                )
+                obj.errors.rejectValue(
+                  'variantNames',
+                  'component.addToList.denied.label'
+                )
+              }
             }
+          }
+          else {
+            log.debug("Ignoring empty variant")
           }
         } else {
           newVariant = KBComponentVariantName.get(it)
@@ -486,10 +552,11 @@ class RestMappingService {
       }
 
       if (notFound.size() == 0) {
-        if (!obj.hasErrors()) {
+        if (!obj.hasErrors() && remove) {
           obj.variantNames.retainAll(remaining)
         }
       } else {
+        log.debug("Unable to look up variants ..")
         obj.errors.reject(
           'component.addToList.denied.label',
           ['variantNames'] as Object[],
@@ -502,6 +569,7 @@ class RestMappingService {
       }
     }
     catch (Exception e) {
+      log.debug("Unable to process variants:", e)
       obj.errors.reject(
         'component.addToList.denied.label',
         ['variantNames'] as Object[],
@@ -513,6 +581,66 @@ class RestMappingService {
       )
     }
     obj
+  }
+
+  @Transactional
+  public def updatePublisher(obj, new_pubs, boolean remove = true) {
+    def errors = []
+    def publisher_combos = obj.getCombosByPropertyName('publisher')
+
+    String propName = obj.isComboReverse('publisher') ? 'fromComponent' : 'toComponent'
+    String tiPropName = obj.isComboReverse('publisher') ? 'toComponent' : 'fromComponent'
+    def pubs_to_add = []
+
+    if (new_pubs instanceof Collection) {
+      new_pubs.each { pub ->
+        if (!pubs_to_add.collect { it.id == pub}) {
+          pubs_to_add << Org.get(pub)
+        }
+        else {
+          log.warn("Duplicate for incoming publisher ${pub}!")
+        }
+      }
+    }
+    else {
+        if (!pubs_to_add.collect { it.id == new_pubs}) {
+          pubs_to_add << Org.get(new_pubs)
+        }
+        else {
+          log.warn("Duplicate for incoming publisher ${new_pubs}!")
+        }
+    }
+
+    pubs_to_add.each { publisher ->
+      boolean found = false
+      for ( int i=0; !found && i<publisher_combos.size(); i++) {
+        Combo pc = publisher_combos[i]
+        def idMatch = pc."${propName}".id == publisher.id
+
+        if (idMatch) {
+          found = true
+        }
+      }
+
+      if (!found) {
+        obj.publisher.add(publisher)
+      } else {
+        log.debug "Publisher ${publisher.name} already set against '${obj.name}'"
+      }
+    }
+
+    if (remove) {
+      Iterator items = publisher_combos.iterator();
+      Object element;
+      while (items.hasNext()) {
+        element = items.next();
+        if (!pubs_to_add.contains(element.toComponent) && !pubs_to_add.contains(element.fromComponent)) {
+          // Remove.
+          element.delete()
+        }
+      }
+    }
+    errors
   }
 
   public def updateLongField(obj, prop, val) {

--- a/server/gokbg3/grails-app/services/org/gokb/OrgService.groovy
+++ b/server/gokbg3/grails-app/services/org/gokb/OrgService.groovy
@@ -1,0 +1,122 @@
+package org.gokb
+
+import grails.gorm.transactions.Transactional
+
+import org.gokb.cred.*
+import org.hibernate.Session
+
+class OrgService {
+
+  def sessionFactory
+  ComponentLookupService componentLookupService
+
+  def restLookup(orgDTO, def user = null) {
+    log.info("Upsert org with header ${orgDTO}");
+    def status_deleted = RefdataCategory.lookupOrCreate('KBComponent.Status','Deleted')
+    def result = [to_create:true]
+    def normname = Org.generateNormname(orgDTO.name)
+
+    log.debug("Checking by normname ${org_normname} ..")
+    def name_candidates = Org.executeQuery("from Org as p where p.normname = ? and p.status <> ?",[org_normname, status_deleted])
+    def ids_list = orgDTO.identifiers ?: orgDTO.ids
+    def matches = [:]
+    def created = false
+    boolean changed = false;
+
+    if(name_candidates.size() > 0) {
+      name_candidates.each { nc ->
+        if (!matches["${nc.id}"])
+          matches["${nc.id}"] = []
+
+        matches["${nc.id}"] << [field: 'name', value: orgDTO.name, message: "Another Organization with this name already exists!"]
+      }
+    }
+
+    if(orgDTO.ids?.size() > 0) {
+      ids_list.each { rid ->
+        Identifier the_id = null
+
+        if (rid instanceof Integer) {
+          the_id = Identifier.get(rid)
+        }
+        else {
+          def ns_field = rid.type ?: rid.namespace
+          def ns = null
+
+          if (ns_field) {
+            if (ns_field instanceof Integer) {
+              ns = IdentifierNamespace.get(ns_field)
+            }
+            else {
+              ns = IdentifierNamespace.findByValueIlike(ns_field)
+            }
+
+            if (ns) {
+              def match = Org.lookupByIO(ns.value, rid.value)
+
+              if (match) {
+                if (!matches["${nc.id}"])
+                  matches["${nc.id}"] = []
+                
+                matches["${nc.id}"] << [field:'ids', value: rid.value, message: "An existing organization was matched by a supplied identifier!"]
+              }
+            }
+          }
+        }
+      }
+    }
+
+    def variant_normname = GOKbTextUtils.normaliseString(orgDTO.name)
+    def variant_matches = Org.executeQuery("select distinct p from Org as p join p.variantNames as v where v.normVariantName = ? and p.status <> ? ",[variant_normname, status_deleted]);
+
+    variant_matches.each { vm ->
+      if (!matches["${vm.id}"])
+        matches["${vm.id}"] = []
+
+      matches["${vm.id}"] << ['field': 'name', value: orgDTO.name, message:"Provided name matched a variant of an existing organization!"]
+    }
+
+    if( orgDTO.variantNames?.size() > 0 ){
+      log.debug("Did not find a match via existing variantNames, trying supplied variantNames..")
+      orgDTO.variantNames.each {
+        def variant = null
+
+        if (it instanceof String) {
+          variant = it.trim()
+        }
+        else if (it instanceof Map) {
+          variant = it.variantName?.trim() ?: null
+        }
+
+        if(variant){
+          def name_matches = Org.findAllByName(variant)
+
+          name_matches.each { nm ->
+            if (!matches["${nm.id}"])
+              matches["${nm.id}"] = []
+
+            matches["${nm.id}"] << [field: 'variantNames', value: variant, message:"Provided variant matched the title of an existing organization!"]
+          }
+
+          def variant_nn = GOKbTextUtils.normaliseString(variant)
+          def variant_candidates = Org.executeQuery("select distinct p from Org as p join p.variantNames as v where v.normVariantName = ? and p.status <> ? ",[variant_nn, status_deleted]);
+
+          variant_candidates.each { vc ->
+            log.debug("Found existing Org variant name for variantName ${variant}")
+            if (!matches["${vc.id}"])
+              matches["${vc.id}"] = []
+
+            matches["${vc.id}"] << ['field': 'variantNames', value: variant, message:"Provided variant matched that of an existing organization!"]
+          }
+        }
+      }
+    }
+    
+    if (matches.size() > 0) {
+      result.to_create = false
+      result.matches = matches
+    }
+
+    result
+  }
+}

--- a/server/gokbg3/grails-app/services/org/gokb/PlatformService.groovy
+++ b/server/gokbg3/grails-app/services/org/gokb/PlatformService.groovy
@@ -1,0 +1,135 @@
+package org.gokb
+
+import grails.gorm.transactions.Transactional
+
+import org.gokb.cred.*
+import org.hibernate.Session
+
+class PlatformService {
+
+  def sessionFactory
+  ComponentLookupService componentLookupService
+
+  def restLookup(platformDTO, def user = null) {
+
+    def result = [to_create: true];
+    def status_current = RefdataCategory.lookupOrCreate('KBComponent.Status', 'Current')
+    def status_deleted = RefdataCategory.lookupOrCreate('KBComponent.Status', 'Deleted')
+    def matches = [:]
+    Boolean viable_url = false;
+
+    if (platformDTO.name.startsWith("http")) {
+      try {
+        log.debug("checking if platform name is an URL..")
+
+        def url_as_name = new URL(platformDTO.name)
+
+        if (url_as_name.getProtocol()) {
+          if (!platformDTO.primaryUrl || !platformDTO.primaryUrl.trim()) {
+            log.debug("identified URL as platform name")
+            platformDTO.primaryUrl = platformDTO.name
+          }
+          platformDTO.name = url_as_name.getHost()
+
+          if (platformDTO.name.startsWith("www.")) {
+            platformDTO.name = platformDTO.name.substring(4)
+          }
+
+          log.debug("New platform name is ${platformDTO.name}.")
+        }
+      } catch (MalformedURLException) {
+        log.debug("Platform name is no valid URL")
+      }
+    }
+
+    name_candidates << Platform.executeQuery("from Platform where name = ? and status != ? ", [platformDTO.name, status_deleted]);
+
+    if (platformDTO.primaryUrl && platformDTO.primaryUrl.trim().size() > 0) {
+      try {
+        def inc_url = new URL(platformDTO.primaryUrl);
+        def other_candidates = []
+
+        if (inc_url) {
+          viable_url = true;
+          String urlHost = inc_url.getHost();
+
+          if (urlHost.startsWith("www.")) {
+            urlHost = urlHost.substring(4)
+          }
+
+          def platform_crit = Platform.createCriteria()
+
+          url_candidates = platform_crit.list {
+            or {
+              like("name", "${urlHost}")
+              like("primaryUrl", "%${urlHost}%")
+            }
+          }
+
+          url_candidates.each { um ->
+            if (!matches["${um.id}"])
+              matches["${um.id}"] = []
+
+            matches["${um.id}"] << ['field': 'primaryUrl', value: platformDTO.primaryUrl, message:"The provided URL matched an existing platform!"]
+          }
+        }
+      } catch (MalformedURLException ex) {
+        log.error("URL of ingest Platform ${platformDTO} is broken!")
+      }
+    }
+
+
+    def variant_normname = GOKbTextUtils.normaliseString(platformDTO.name)
+    def variant_matches = Platform.executeQuery("select distinct pl from Platform as pl join pl.variantNames as v where v.normVariantName = ? and pl.status = ? ", [variant_normname, status_current])
+
+    variant_matches.each { vm ->
+      if (!matches["${vm.id}"])
+        matches["${vm.id}"] = []
+
+      matches["${vm.id}"] << ['field': 'name', value: platformDTO.name, message:"Provided name matched a variant of an existing platform!"]
+    }
+
+    if( platformDTO.variantNames?.size() > 0 ){
+      log.debug("Did not find a match via existing variantNames, trying supplied variantNames..")
+      platformDTO.variantNames.each {
+        def variant = null
+
+        if (it instanceof String) {
+          variant = it.trim()
+        }
+        else if (it instanceof Map) {
+          variant = it.variantName?.trim() ?: null
+        }
+
+        if(variant){
+          def name_matches = Platform.findAllByName(variant)
+
+          name_matches.each { nm ->
+            if (!matches["${nm.id}"])
+              matches["${nm.id}"] = []
+
+            matches["${nm.id}"] << [field: 'variantNames', value: variant, message:"Provided variant matched the title of an existing platform!"]
+          }
+
+          def variant_nn = GOKbTextUtils.normaliseString(variant)
+          def variant_candidates = Platform.executeQuery("select distinct p from Platform as p join p.variantNames as v where v.normVariantName = ? and p.status <> ? ",[variant_nn, status_deleted]);
+
+          variant_candidates.each { vc ->
+            log.debug("Found existing Platform variant name for variantName ${variant}")
+            if (!matches["${vc.id}"])
+              matches["${vc.id}"] = []
+
+            matches["${vc.id}"] << [field: 'variantNames', value: variant, message:"Provided variant matched that of an existing platform!"]
+          }
+        }
+      }
+    }
+
+    if (matches.size() > 0) {
+      to_create = false
+      result.matches = matches
+    }
+
+    result
+  }
+}

--- a/server/gokbg3/grails-app/services/org/gokb/TitleLookupService.groovy
+++ b/server/gokbg3/grails-app/services/org/gokb/TitleLookupService.groovy
@@ -13,7 +13,7 @@ class TitleLookupService {
   def grailsApplication
   def componentLookupService
   def genericOIDService
-  
+
 
   @javax.annotation.PostConstruct
   def init() {
@@ -34,6 +34,7 @@ class TitleLookupService {
       "ids"               : [],
       "matches"           : [] as Set,
       "other_matches"     : [] as Set,
+      "other_types"       : [] as Set,
       "x_check_matches"   : [] as Set,
       "other_identifiers" : [] as Set
     ]
@@ -65,7 +66,7 @@ class TitleLookupService {
         id_def.value = the_id.value
         id_def.type = the_id.namespace.value
       }
-      
+
       // is a class 1 identifier.
       if ( id_def.type && id_def.value ) {
 
@@ -89,7 +90,7 @@ class TitleLookupService {
 
         // Flag for title match
         boolean title_match = false
-        
+
         // If we find an ID then lookup the components.
         Set<KBComponent> comp = getComponentsForIdentifier(the_id)
 
@@ -116,54 +117,55 @@ class TitleLookupService {
             log.debug("ID Doesn't point at a title, skipping");
           }
         }
-        
+
         // Did the ID yield a Title match?
         log.debug("After class one matches (${id_def.type}:${id_def.value}, ${the_id.id}, title_match=${title_match}");
 
         if (!title_match) {
-          
+
           // We should see if the current ID namespace should be cross checked with another.
           def other_ns = null
           for (int i=0; i<xcheck.size() && (!(other_ns)); i++) {
             Set<String> test = xcheck[i]
-            
+
             if (test.contains(id_def.type)) {
-              
+
               // Create the set then remove the matched instance to test teh remaining ones.
               other_ns = new HashSet<String>(test)
-              
+
               // Remove the current namespace.
               other_ns.remove(id_def.type)
               log.debug ("Cross checking for ${id_def.type} in ${other_ns.join(", ")}")
-              
+
               Identifier xc_id = null
               for (int j=0; j<other_ns.size() && !(xc_id); j++) {
-                
+
                 String ns = other_ns[j]
-                
+
                 IdentifierNamespace namespace = IdentifierNamespace.findByValue(ns)
-                
+
                 if (namespace) {
                   // Lookup the identifier namespace.
-                  xc_id = Identifier.findByNamespaceAndValue(namespace, id_def.value)                  
+                  xc_id = Identifier.findByNamespaceAndValue(namespace, id_def.value)
                   log.debug ("Looking up ${ns}:${id_def.value} returned Identifier ${xc_id}");
-                  
+
                   comp = xc_id?.identifiedComponents
-                  
+
                   comp?.each { KBComponent c ->
-        
+
                     // Ensure we're not looking at a Hibernate Proxy class representation of the class
-                    KBComponent dproxied = ClassUtils.deproxy(c);
-        
+                    def dproxied = ClassUtils.deproxy(c);
+
                     // Only add if it's a title.
-                    if ( dproxied instanceof TitleInstance ) {
-                      
+                    if ( dproxied.class.name == ti_class.name ) {
+
                       log.debug ("Found ${id_def.value} in ${ns} namespace.")
-                      
+
                       // Save details here so we can raise a review request, only if a single title was matched.
                       result['x_check_matches'] << [
                         "suppliedNS"  : id_def.type,
-                        "foundNS"     : ns
+                        "foundNS"     : ns,
+                        "value"       : id_def.value
                       ]
 
                       TitleInstance the_ti = (dproxied as TitleInstance)
@@ -179,6 +181,16 @@ class TitleLookupService {
                       else {
                         result['matches'] << the_ti
                         log.debug("Adding cross check title to matches (Now ${result['matches'].size()} items)");
+                      }
+                    }
+                    else {
+                      log.debug("Found other linked component type: ${c} (${dproxied.class.name})")
+
+                      if (result['other_types'].contains(c)) {
+                        log.debug("Component already in list of matched instances")
+                      }
+                      else {
+                        result['other_types'].add(c)
                       }
                     }
                   }
@@ -200,6 +212,233 @@ class TitleLookupService {
     result
   }
 
+  def find(String title,
+            def publisher,
+            def identifiers,
+            def newTitleClassName
+          ) {
+    def result = [to_create: false, matches: []]
+    TitleInstance the_title = null
+    Class ti_class = Class.forName(newTitleClassName)
+
+    // Lookup any class 1 identifier matches
+    def results = class_one_match (identifiers, ti_class)
+
+    // The matches.
+    List< KBComponent> matches = results['matches'] as List
+
+    switch (matches.size()) {
+      case 0 :
+        // No match behaviour.
+        log.debug ("Title class one identifier lookup yielded no matches.")
+
+
+        // Check for presence of class one ID
+        if (results['class_one']) {
+          result.to_create = true
+        } else {
+
+          // No class 1s supplied we should try and find a match on the title string.
+          if (results['other_matches'].size() > 0){
+            if (results['other_matches'].size() == 1) {
+              log.debug("Matched item by secondary ID ..")
+              the_title = results['other_matches'][0]
+              result.matches.add([object:the_title, conflicts:[], warnings:['secondary']])
+            }
+            else if (results['other_matches'].size() > 1) {
+              log.debug("Multiple matches by secondary ID!")
+              results.other_matches.each { om
+                result.matches.add([object:om, conflicts:[], warnings:['secondary','other_matches']])
+              }
+            }
+          }
+
+          if (!the_title) {
+            log.debug ("No class 1 ids supplied. attempting string match")
+
+            // The hash we use is constructed differently based on the type of items.
+            // Serial hashes are based soley on the title, Monographs are based currently on title+primary author surname
+            def target_hash = null;
+
+            // Lookup using title string match only.
+            def string_matched = attemptComponentMatch ([title:title], newTitleClassName)
+
+            if (string_matched) {
+              log.debug("TI matched by bucket.")
+              def title_match = [object:the_title, warnings:['bucket']]
+
+              if ( title != the_title.name ) {
+                title_match.conflicts.add([message: "Found a title with a different primary name!", field: "name", value: title, matched: the_title.name])
+              }
+
+              result.matches.add(title_match)
+            }
+
+            result.to_create = true
+          }
+        }
+        break;
+      case 1 :
+        // Single component match.
+        log.debug ("Title class one identifier lookup yielded a single match.")
+        def title_match = [object: matches[0], conflicts:[], warnings:[]]
+
+        // We should raise a review request here if the match was made by cross checking
+        // different identifier namespaces.
+        if (results['x_check_matches'].size() == 1 && results['x_check_matches'][0]['suppliedNS'] != 'issnl') {
+
+          def data = results['x_check_matches'][0]
+
+          title_match.conflicts << [
+            message: "Title ${data['suppliedNS']} value ${data['value']} matched an existing ${data['foundNS']}",
+            field: "identifier.namespace",
+            value: "${data['suppliedNS']}:${data['value']}",
+            matched: "${data['foundNS']}:${data['value']}"
+          ]
+        }
+
+        // If one identifier matches, but all other class ones are different, it is probably not a real match.
+
+        def id_mismatches = []
+
+        results['ids'].each { rid ->
+          matches[0].ids.each { mid ->
+            if ( rid.namespace == mid.namespace && rid.value != mid.value ) {
+              if ( !matches[0].ids.contains(rid) ) {
+                id_mismatches.add([incoming:rid, matched:mid])
+              }
+            }
+          }
+        }
+
+
+        // Take whatever we can get if what we have is an unknown title
+        if ( title.startsWith("Unknown Title") ) {
+          // Don't go through title matching if we don't have a real title
+          title_match.warnings.add('title_ignored')
+        }
+        else {
+          if ( matches[0].name.startsWith("Unknown Title") ) {
+            // If we have an unknown title in the db, and a real title, then take that
+            // in preference
+            log.debug("Found new Title ${metadata.title} for previously unknown title ${matches[0]} (${matches[0].name})")
+            title_match.warnings.add('title_placeholder')
+          }
+          else {
+            if ( matches[0].name.equals(title) || matches[0].normname?.equals(KBComponent.generateNormname(title)) ) {
+
+            }
+            else {
+              title_match.conflicts << [
+                message: "Ingest name differs from that of the matched title!",
+                field: "name",
+                value: title,
+                matched: matches[0].name
+              ]
+
+              if (id_mismatches.size() > 0) {
+                result.to_create = true
+              }
+            }
+
+            if( id_mismatches.size() > 0 ){
+              id_mismatches.each {
+                title_match.conflicts << [
+                  message: "Value ${it.incoming.value} for namespace ${it.incoming.namespace.value} conflicts with existing value ${it.matched.value}",
+                  field: "identifier.value",
+                  value: it.incoming.value,
+                  matched: it.matched.value
+                ]
+              }
+            }
+          }
+        }
+        result.matches << title_match
+        break;
+
+      default :
+        // Multiple matches.
+        log.debug ("Title class one identifier lookup yielded ${matches.size()} matches - ${matches}.")
+        def all_matched = []
+        def partial = []
+        RefdataValue status_deleted = RefdataCategory.lookupOrCreate('KBComponent.Status', 'Deleted')
+
+        matches.each { mti ->
+
+          def full_match = true
+          def id_conflicts = []
+
+          results['ids'].each { rid ->
+            mti.ids.each { mid ->
+              if ( rid.namespace == mid.namespace && rid.value != mid.value ) {
+                if ( !mti.ids.contains(rid) ) {
+                  full_match = false
+                  id_conflicts.add([message: "Value ${rid.value} for namespace ${rid.namespace.value} conflicts with existing value ${mid.value}", field: "identifier.value", value:rid.value, matched:mid.value])
+                }
+              }
+            }
+          }
+
+          if ( full_match ) {
+            if ( mti.status != status_deleted ) {
+              all_matched.add(mti)
+            }
+            else {
+              log.debug("Skipping matched TI with status 'Deleted'!")
+            }
+          } else if ( mti.status != status_deleted ) {
+            partial.add([object:mti, conflicts: id_conflicts, warnings:['other_matches']])
+          }
+
+        }
+
+        switch ( all_matched.size() ) {
+          case 0 :
+            log.debug("Multiple matches for a single identifier. No matches for all class ones. Creating new TI!")
+            result.to_create = true
+            result.matches = partial
+            break;
+
+          case 1 :
+            log.debug("One match for all identifiers")
+            def title_match = [object: all_matched[0], conflicts:[], warnings:['other_matches']]
+
+            if(!all_matched[0].name.equals(title)){
+              title_match.conflicts << [message: "Title name differs from matched value ${all_matched[0].name}", field: "name", value: title, matched: all_matched[0].name]
+            }
+
+            result.matches << title_match
+            break;
+
+          default :
+            log.debug("Multiple matches for given ingest identifiers. Trying to match by name..")
+
+            def matched_with_name = []
+
+            all_matched.each { mti ->
+              if ( mti.name.equals(title) || mti.normname?.equals(KBComponent.generateNormname(title)) ) {
+                matched_with_name.add(mti)
+              }
+            }
+
+            if ( matched_with_name.size() == 1 ){
+              log.debug("Only one matched TI (${matched_with_name[0]}) has the same name!")
+              result.matches << [object: matched_with_name[0], conflicts:[], warnings:['other_matches']]
+            }
+            else {
+              log.debug("Could not match a specific title. Skipping..")
+
+              all_matched.each {
+                result.matches << [object: it, conflicts:[], warnings:['duplicate']]
+              }
+            }
+            break;
+        }
+        break;
+    }
+    result
+  }
+
 
   /**
    * @param title
@@ -207,23 +446,24 @@ class TitleLookupService {
    * @param identifiers : map [ [ type: 'idtype', value:'idvalue' ], [ type:'idtype', value:'idvalue' ] ]
    */
 
-  def find (String title,
-            String publisher_name, 
-            def identifiers, 
-            def user = null, 
+  def findOrCreate (String title,
+            String publisher_name,
+            def identifiers,
+            def user = null,
             def project = null,
             def newTitleClassName = 'org.gokb.cred.JournalInstance',
             def uuid = null) {
-    return findTitle([title:title, publisher_name:publisher_name,identifiers:identifiers,uuid:uuid],user,project,newTitleClassName)
+    return findOrCreateTitle([title:title, publisher_name:publisher_name,identifiers:identifiers,uuid:uuid],user,project,newTitleClassName)
   }
 
   private final findLock = new Object()
 
   @Synchronized("findLock")
-  private def findTitle (Map metadata,
-            def user = null, 
+  private def findOrCreateTitle (Map metadata,
+            def user = null,
             def project = null,
-            def newTitleClassName = 'org.gokb.cred.JournalInstance') {
+            def newTitleClassName = 'org.gokb.cred.JournalInstance'
+  ) {
 
     // The TitleInstance
     TitleInstance the_title = null
@@ -256,7 +496,7 @@ class TitleLookupService {
         // No match behaviour.
         log.debug ("Title class one identifier lookup yielded no matches.")
 
-     
+
         // Check for presence of class one ID
         if (results['class_one']) {
           log.debug ("One or more class 1 IDs supplied so must be a new TI.")
@@ -270,7 +510,7 @@ class TitleLookupService {
             the_title = ti_class.newInstance()
             the_title.name = metadata.title
             the_title.normname = KBComponent.generateNormname(metadata.title);
-            // the_title.editStatus = 
+            // the_title.editStatus =
             the_title.ids = []
           }
 
@@ -292,6 +532,8 @@ class TitleLookupService {
             }
           }
 
+          def string_match = null
+
           if (!the_title) {
             log.debug ("No class 1 ids supplied. attempting string match")
 
@@ -300,11 +542,11 @@ class TitleLookupService {
             def target_hash = null;
 
             // Lookup using title string match only.
-            the_title = attemptComponentMatch (metadata, newTitleClassName)
+            string_match = attemptComponentMatch (metadata, newTitleClassName)
           }
 
           if (the_title) {
-            log.debug("TI ${the_title} matched by bucket.")
+            log.debug("TI ${the_title} matched by secondary ID.")
 
             if ( metadata.title != the_title.name ) {
               log.debug("bucket match but \"${metadata.title}\" != \"${the_title.name}\" so add as a variant");
@@ -318,7 +560,7 @@ class TitleLookupService {
                 ReviewRequest.raise(
                     the_title,
                     "'${metadata.title}' added as a variant of '${the_title.name}'.",
-                    "No 1st class ID supplied but reasonable match was made on the title name.",
+                    "Title was matched via secondary id, but had a different name.",
                     user, project
                     )
               }
@@ -329,7 +571,6 @@ class TitleLookupService {
             }
 
           } else {
-
             log.debug("No TI could be matched by name. New TI, flag for review.")
 
             // Could not match on title either.
@@ -351,25 +592,41 @@ class TitleLookupService {
 
             title_created = true
 
-            ReviewRequest.raise(
+            if (string_match) {
+              def additionalInfo = [:]
+              def combo_ids = [the_title]
+
+              additionalInfo.otherComponents = []
+
+              matches.each { tlm ->
+                additionalInfo.otherComponents.add([oid:"${tlm.logEntityId}",name:"${tlm.name ?: tlm.displayName}"])
+                combo_ids.add(tlm.id)
+              }
+
+              additionalInfo.cstring = combo_ids.sort().join('_')
+
+              ReviewRequest.raise(
                 the_title,
                 "New TI created.",
-                "No 1st class ID supplied and no match could be made on title name.",
-                user, project
-                )
+                "No matched components via IDs, but a title with a similar name already exists.",
+                user,
+                project,
+                (additionalInfo as JSON).toString()
+              )
+            }
           }
         }
         break;
       case 1 :
         // Single component match.
         log.debug ("Title class one identifier lookup yielded a single match.")
-        
+
         // We should raise a review request here if the match was made by cross checking
         // different identifier namespaces.
         if (results['x_check_matches'].size() == 1 && results['x_check_matches'][0]['suppliedNS'] != 'issnl') {
-          
+
           def data = results['x_check_matches'][0]
-          
+
           // Fire the review request.
           ReviewRequest.raise(
             matches[0],
@@ -394,16 +651,7 @@ class TitleLookupService {
           }
         }
 
-//         if( id_mismatches > 0 ) {
-//           ReviewRequest.raise(
-//             matches[0],
-//             "Identifier mismatch.",
-//             "Ingest identifier differs from existing one in the same namespace.",
-//             user,
-//             project
-//           )
-//         }
-        
+
         // Take whatever we can get if what we have is an unknown title
         if ( metadata.title.startsWith("Unknown Title") || metadata.status == "Expected" ) {
           // Don't go through title matching if we don't have a real title
@@ -419,7 +667,7 @@ class TitleLookupService {
             the_title.status = RefdataCategory.lookupOrCreate('KBComponent.Status', 'Current')
           }
           else {
-            if ( matches[0].name.equals(metadata.title) || matches[0].normname?.equals(KBComponent.generateNormname(metadata.title)) ) { 
+            if ( matches[0].name.equals(metadata.title) || matches[0].normname?.equals(KBComponent.generateNormname(metadata.title)) ) {
               // Perfect match - do nothing
               the_title = matches[0]
 
@@ -605,6 +853,8 @@ class TitleLookupService {
             }
             else {
               log.debug("Could not match a specific title. Skipping..")
+              def matched_ids = matched_with_name.collect {it.id}
+              throw new org.gokb.exceptions.MultipleComponentsMatchedException("Could not match a specific title!", metadata.title, metadata.identifiers, matched_ids)
             }
             break;
         }
@@ -625,11 +875,37 @@ class TitleLookupService {
           the_title.status = RefdataCategory.lookupOrCreate(KBComponent.RD_STATUS, 'Expected')
         }
 
-        if(title_created) {
+        log.debug("${the_title.ids}")
+
+        if (title_created) {
           the_title.save(flush:true)
         }
         else {
           the_title = the_title.merge(flush:true)
+        }
+
+        if (results.other_matches.size() > 0) {
+
+          def additionalInfo = [:]
+          def combo_ids = [the_title]
+
+          additionalInfo.otherComponents = []
+
+          results.other_matches.each { tlm ->
+            additionalInfo.otherComponents.add([oid:"${tlm.logEntityId}",name:"${tlm.name ?: tlm.displayName}"])
+            combo_ids.add(tlm.id)
+          }
+
+          additionalInfo.cstring = combo_ids.sort().join('_')
+
+          ReviewRequest.raise(
+            the_title,
+            "Identifier match.",
+            "A provided identifier matched an existing component of another type!",
+            user,
+            project,
+            (additionalInfo as JSON).toString()
+          )
         }
       }
       else {
@@ -643,20 +919,20 @@ class TitleLookupService {
   private TitleInstance addPublisher (publisher_name, ti, user = null, project = null) {
 
 
-    if ( ( publisher_name != null ) && 
+    if ( ( publisher_name != null ) &&
          ( publisher_name.trim().length() > 0 ) ) {
-         
+
       log.debug("Add publisher \"${publisher_name}\"")
       Org publisher = Org.findByName(publisher_name)
       def norm_pub_name = Org.generateNormname(publisher_name);
       def status_deleted = RefdataCategory.lookup("KBComponent.Status", "Deleted")
-      
+
       if ( !publisher ) {
         // Lookup using norm name.
-        
+
         log.debug("Using normname \"${norm_pub_name}\" for lookup")
         publisher = Org.findByNormname(norm_pub_name)
-      }      
+      }
 
       if ( !publisher || publisher.status == status_deleted) {
         def variant_normname = GOKbTextUtils.normaliseString(publisher_name)
@@ -702,6 +978,7 @@ class TitleLookupService {
         log.debug("Not adding duplicate ID ${new_id}..")
       }
     }
+    ti.save(flush:true)
     ti
   }
 
@@ -709,7 +986,7 @@ class TitleLookupService {
     def t = null;
     if ( title && ( title.length() > 0 ) ) {
       def nname = GOKbTextUtils.norm2(title);
-      
+
       def bucket_hash = GOKbTextUtils.generateComponentHash([nname]);
 
       // def component_hash = GOKbTextUtils.generateComponentHash([nname, componentDiscriminator]);
@@ -761,7 +1038,7 @@ class TitleLookupService {
     log.debug("singleTIMatch");
 
     String comparable_title = GOKbTextUtils.generateComparableKey(title)
-    
+
     // The threshold for a good match.
     double threshold = grailsApplication.config.cosine.good_threshold
 
@@ -812,36 +1089,36 @@ class TitleLookupService {
     ti
   }
 
-  
+
   /**
-   * @param ids should be a list of maps containing at least an ns and value key. 
+   * @param ids should be a list of maps containing at least an ns and value key.
    * @return
    */
   public def matchClassOnes (def ids) {
     def result = [] as Set
-    
+
     // Get the class 1 identifier namespaces.
     Set<String> class_one_ids = grailsApplication.config.identifiers.class_ones
 
     def start_time = System.currentTimeMillis();
-    
+
     ids.each { def id_def ->
 
       log.debug("Consider ${id_def}");
 
       // Class ones only.
-      if ( id_def.value && 
-           id_def.ns && 
+      if ( id_def.value &&
+           id_def.ns &&
            class_one_ids.contains(id_def.ns) ) {
 
         log.debug("looking up ${id_def}");
-      
+
         def identifiers = Identifier.createCriteria().list(max: 5) {
-          and { 
+          and {
             namespace {
               inList "value", id_def.ns
             }
-            
+
             eq "value", id_def.value
           }
         }
@@ -851,7 +1128,7 @@ class TitleLookupService {
         if ( identifiers.size() > 4 ) {
           log.warn("matchClassOne for ${id_def} returned a high number of candidate records. This shouldn't be the case");
         }
-        
+
         // Examine the identified components.
         identifiers?.each {
           log.debug("Handle ${it?.identifiedComponents.size()} components");
@@ -870,7 +1147,7 @@ class TitleLookupService {
     if ( elapsed > 2000 ) {
       log.warn("matchClassOnes took much longer than expected to complete when processing ${ids}. Needs investigation");
     }
-    
+
     result
   }
 
@@ -882,29 +1159,29 @@ class TitleLookupService {
     try {
       // Get the class 1 identifier namespaces.
       Set<String> class_one_ids = grailsApplication.config.identifiers.class_ones
-  
+
       def start_time = System.currentTimeMillis();
       def status_deleted = RefdataCategory.lookup('KBComponent.Status', 'Deleted')
       def combo_id_type = RefdataCategory.lookup('Combo.Type', 'KBComponent.Ids')
-  
+
       def bindvars = []
       StringWriter sw = new StringWriter()
       sw.write("select DISTINCT c.fromComponent.id from Combo as c where ( ")
-  
-  
+
+
       def ctr = 0;
       ids.each { def id_def ->
         // Class ones only.
-        if ( id_def.value && id_def.ns && class_one_ids.contains(id_def.ns) ) { 
+        if ( id_def.value && id_def.ns && class_one_ids.contains(id_def.ns) ) {
           def ns = IdentifierNamespace.findByValue(id_def.ns)
           if ( ns ) {
-  
+
             def the_id = Identifier.executeQuery('select i from Identifier as i where i.value = ? and i.namespace = ?',[id_def.value, ns])
             if ( the_id.size() == 1 ) {
               if ( ctr++ ) {
                 sw.write(" or ");
               }
-  
+
               sw.write( "( c.toComponent = ? )" )
               bindvars.add(the_id[0])
             }
@@ -915,8 +1192,8 @@ class TitleLookupService {
           }
         }
       }
-  
-  
+
+
       if ( ctr > 0 ) {
         sw.write(" ) and c.type=? and c.fromComponent.status != ?");
         bindvars.add(combo_id_type);
@@ -950,7 +1227,7 @@ class TitleLookupService {
     }
     log.debug("getTitleFieldForIdentifier(${ids},${field_name} : ${result}");
     return result
-  } 
+  }
 
   // A task will be created to remap a title instance by an update to that title which touches
   // any field that might change the Instance -> Work mapping. We have to wait for that update to
@@ -975,7 +1252,7 @@ class TitleLookupService {
   }
 
   def getComponentsForIdentifier(identifier) {
-    
+
     def status_deleted = RefdataCategory.lookup('KBComponent.Status', 'Deleted')
     // was identifier.identifiedComponents
     KBComponent.executeQuery('select DISTINCT c.fromComponent from Combo as c where c.toComponent = :id and c.type.value = :tp and c.fromComponent.status <> :del',[id:identifier,tp:'KBComponent.Ids', del: status_deleted]);

--- a/server/gokbg3/src/integration-test/groovy/gokbg3/rest/IdentifierTestSpec.groovy
+++ b/server/gokbg3/src/integration-test/groovy/gokbg3/rest/IdentifierTestSpec.groovy
@@ -118,7 +118,7 @@ class IdentifierTestSpec extends AbstractAuthSpec {
     }
     then:
     resp.status == 400 // Created
-    resp.json.message == "Identifier format check failed!"
+    resp.json.message == "Identifier has failed validation!"
   }
 
   void "test identifier create with connected component"() {

--- a/server/gokbg3/src/integration-test/groovy/gokbg3/rest/PackageTestSpec.groovy
+++ b/server/gokbg3/src/integration-test/groovy/gokbg3/rest/PackageTestSpec.groovy
@@ -116,6 +116,7 @@ class PackageTestSpec extends AbstractAuthSpec {
     }
     then:
     resp.status == 200 // OK
+    sleep(500)
     resp.json._embedded?.curatoryGroups?.size() == 1
     resp.json._embedded?.curatoryGroups[0].id == testGroup.id
   }

--- a/server/gokbg3/src/main/groovy/org/gokb/exceptions/MultipleComponentsMatchedException.groovy
+++ b/server/gokbg3/src/main/groovy/org/gokb/exceptions/MultipleComponentsMatchedException.groovy
@@ -1,0 +1,28 @@
+package org.gokb.exceptions;
+
+public class MultipleComponentsMatchedException extends java.lang.Exception {
+
+  public String proposed_title
+  public List identifiers
+  public List matched_ids
+  public String matched_title
+
+  public MultipleComponentsMatchedException(String message) {
+    super(message)
+  }
+
+  public MultipleComponentsMatchedException(String message, Throwable cause) {
+    super(message,cause);
+  }
+
+  public MultipleComponentsMatchedException(String message,
+                                              String proposed_title,
+                                              List identifiers,
+                                              List matched_ids) {
+    super(message)
+    this.proposed_title=proposed_title
+    this.identifiers=identifiers
+    this.matched_ids=matched_ids
+  }
+
+}


### PR DESCRIPTION
- move lookup for existing components to dedicated service methods (Title, Package, Platform & Org)
- change REST save() behavior from upsert to lookup
- change TIPP rest endpoint to `/package-titles`
- improve Package validation (validateDTO)
- set Combo status to `active` by default
- fix domain class validation by name
- restrict title class_one matches to results of specific subclass (and simply add RR for other conflicts) (#273)
- add new MultipleComponentsMatchedException to transport info about unsolvable matching scenarios
- fix missing variable in OrgController (#289 )