### PR TITLE
Integration jobs

### DIFF
--- a/server/gokbg3/grails-app/conf/application.yml
+++ b/server/gokbg3/grails-app/conf/application.yml
@@ -5,6 +5,10 @@ grails:
             - ~/.grails/gokb-config.groovy
             - ~/.grails/gokb-config.yml
             - ~/.grails/gokb-config.properties
+    cors:
+      enabled: true
+      mappings:
+        /rest/**: inherit
 
     profile: web
     codegen:

--- a/server/gokbg3/grails-app/conf/application.yml
+++ b/server/gokbg3/grails-app/conf/application.yml
@@ -6,9 +6,9 @@ grails:
             - ~/.grails/gokb-config.yml
             - ~/.grails/gokb-config.properties
     cors:
-      enabled: true
-      mappings:
-        /rest/**: inherit
+        enabled: true
+        mappings:
+            /rest/**: inherit
 
     profile: web
     codegen:

--- a/server/gokbg3/grails-app/controllers/gokbg3/UrlMappings.groovy
+++ b/server/gokbg3/grails-app/controllers/gokbg3/UrlMappings.groovy
@@ -80,6 +80,7 @@ class UrlMappings {
       get "/identifier-namespaces"(controller: 'identifier', namespace: 'rest', action: 'namespace')
 
       get "/profile"(controller: 'profile', namespace: 'rest', action: 'show')
+      get "/profile/jobs/"(controller: 'profile', namespace: 'rest', action: 'getJobs')
       put "/profile"(controller: 'profile', namespace: 'rest', action: 'update')
       patch "/profile"(controller: 'profile', namespace: 'rest', action: 'patch')
       delete "/profile"(controller: 'profile', namespace: 'rest', action: 'delete')
@@ -103,6 +104,7 @@ class UrlMappings {
       patch "/reviews/$id"(controller: 'reviews', namespace: 'rest', action: 'update')
 
       get "/curatoryGroups/$id/reviews"(controller: 'curatoryGroups', namespace: 'rest', action: 'getReviews')
+      get "/curatoryGroups/$id/jobs"(controller: 'curatoryGroups', namespace: 'rest', action: 'getJobs') 
       get "/curatoryGroups/$id"(controller: 'curatoryGroups', namespace: 'rest', action: 'show')
       get "/curatoryGroups"(controller: 'curatoryGroups', namespace: 'rest', action: 'index')
 

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Combo.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Combo.groovy
@@ -69,8 +69,12 @@ class Combo implements Auditable {
 
   def afterInsert() {
     if (this.status == null) {
-      this.status = DomainClassExtender.getComboStatusActive()
-      this.save()
+      log.debug("Setting default combo status ..")
+      setStatus(DomainClassExtender.getComboStatusActive())
+      save()
+    }
+    else {
+      log.debug("Combo status is ${this.status}")
     }
   }
   

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Combo.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Combo.groovy
@@ -68,8 +68,9 @@ class Combo implements Auditable {
   }
 
   def afterInsert() {
-    if (!status) {
-      status = DomainClassExtender.getComboStatusActive()
+    if (this.status == null) {
+      this.status = DomainClassExtender.getComboStatusActive()
+      this.save()
     }
   }
   

--- a/server/gokbg3/grails-app/services/com/k_int/ConcurrencyManagerService.groovy
+++ b/server/gokbg3/grails-app/services/com/k_int/ConcurrencyManagerService.groovy
@@ -47,6 +47,8 @@ class ConcurrencyManagerService {
     boolean begun = false;
     String description
     List messages = []
+    int ownerId
+    int groupId
 
     public message(String message) {
       log.debug(message);
@@ -242,7 +244,7 @@ class ConcurrencyManagerService {
    * @param job_id
    * @return the Job
    */
-  public Job getJob(int job_id){
+  public Job getJob(int job_id) {
     if (job_id == null || !this.map.containsKey(job_id)) {
       return null
     }
@@ -258,5 +260,89 @@ class ConcurrencyManagerService {
 
     // Return the job.
     j
+  }
+
+  /**
+   * Gets all Jobs for the supplied User id.
+   * @param user_id
+   * @param max
+   * @param offset
+   * @return List of Jobs
+   */
+  public List getUserJobs(int user_id, int max, int offset) {
+    def allJobs = getJobs()
+    def selected = []
+    def result = []
+
+    if (user_id == null) {
+      return null
+    }
+
+    // Get the jobs.
+    allJobs.each { k, v ->
+      if (v.ownerId == user_id) {
+        selected << [
+          id: v.id,
+          progress: v.progress,
+          messages: v.messages,
+          description: v.description,
+          begun: v.begun,
+          startTime: v.startTime,
+          endTime: v.endTime
+        ]
+      }
+    }
+
+    if (offset > 0) {
+      selected = selected.drop(offset)
+    }
+
+    result = selected.take(max)
+
+    // Return the jobs.
+    result
+  }
+
+  /**
+   * Gets all Jobs for the supplied CuratoryGroup id.
+   * @param group_id
+   * @param max
+   * @param offset
+   * @return List of Jobs
+   */
+  public List getGroupJobs(int group_id, int max = 10, int offset = 0) {
+    def allJobs = getJobs()
+    def selected = []
+    def result = []
+
+    if (group_id == null) {
+      return null
+    }
+
+    log.debug("Getting jobs for group ${group_id}")
+
+    // Get the jobs.
+    allJobs.each { k, v ->
+      if (v.groupId == group_id) {
+        selected << [
+          id: v.id,
+          progress: v.progress,
+          messages: v.messages,
+          description: v.description,
+          begun: v.begun,
+          startTime: v.startTime,
+          endTime: v.endTime
+        ]
+      }
+    }
+
+    if (offset > 0) {
+      selected = selected.drop(offset)
+    }
+
+    result = selected.take(max)
+
+    // Return the jobs.
+    result
   }
 }

--- a/server/gokbg3/grails-app/views/admin/jobs.gsp
+++ b/server/gokbg3/grails-app/views/admin/jobs.gsp
@@ -21,6 +21,7 @@
         <th>Description</th>
         <th>Has Started</th>
         <th>Start Time</th>
+        <th>Group</th>
         <th>Status</th>
         <th>End Time</th>
         <th>Actions</th>
@@ -33,6 +34,7 @@
           <td>${v.description}</td>
           <td>${v.begun}</td>
           <td>${v.startTime}</td>
+          <th>${v.groupId}</th>
           <td>
             <g:if test="${v.isCancelled()}">
               Cancelled

--- a/server/gokbg3/grails-app/views/admin/jobs.gsp
+++ b/server/gokbg3/grails-app/views/admin/jobs.gsp
@@ -18,10 +18,10 @@
     <thead>
       <tr>
         <th>ID</th>
+        <th>Group-ID</th>
         <th>Description</th>
         <th>Has Started</th>
         <th>Start Time</th>
-        <th>Group</th>
         <th>Status</th>
         <th>End Time</th>
         <th>Actions</th>
@@ -31,10 +31,10 @@
       <g:each in="${jobs}" var="k,v">
         <tr class="${k==params.highlightJob?'highlightRow':''}">
           <td rowspan="2">${k}</td>
+          <td>${v.groupId}</td>
           <td>${v.description}</td>
           <td>${v.begun}</td>
           <td>${v.startTime}</td>
-          <th>${v.groupId}</th>
           <td>
             <g:if test="${v.isCancelled()}">
               Cancelled


### PR DESCRIPTION
- Add `ownerId` (User) & `groupId` (CuratoryGroup) to ConcurrencyManagerService Job
- Set Job ownership via crossReferencing endpoints
- Enable CORS for REST endpoints
- Add `jobs` endpoints for `/rest/profile` & `/rest/curatoryGroups`
- Allow setting UpdateToken for new Packages created via crossReferencePackage (`packageHeader.generateToken = true`)
- Add User check for retrieving Jobs via ownerId
- Fix Combo default status