### PR TITLE
two changes according to Bug reports

### DIFF
--- a/server/gokbg3/grails-app/controllers/org/gokb/OaiController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/OaiController.groovy
@@ -95,7 +95,8 @@ class OaiController {
   }
 
   def getRecord(result) {
-
+    // long session for possible huge requests
+    request.getSession(true).setMaxInactiveInterval(12000)
     log.debug("getRecord - ${result}");
 
     def errors = []
@@ -455,6 +456,8 @@ class OaiController {
 
 
   def listRecords(result) {
+    // long session for possible huge requests
+    request.getSession(true).setMaxInactiveInterval(12000)
     response.contentType = "text/xml"
     response.setCharacterEncoding("UTF-8");
     def out = response.outputStream

--- a/server/gokbg3/grails-app/domain/org/gokb/cred/KBComponent.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/KBComponent.groovy
@@ -1366,6 +1366,8 @@ where cp.owner = :c
     KBComponentVariantName.executeUpdate("delete from KBComponentVariantName as c where c.owner=:component", [component: this])
 
     ReviewRequestAllocationLog.executeUpdate("delete from ReviewRequestAllocationLog as c where c.rr in ( select r from ReviewRequest as r where r.componentToReview=:component)", [component: this]);
+    AllocatedReviewGroup.executeUpdate("delete from AllocatedReviewGroup as g where g.review in ( select r from ReviewRequest as r where r.componentToReview=:component)", [component: this]);
+
     def events_to_delete = ComponentHistoryEventParticipant.executeQuery("select c.event from ComponentHistoryEventParticipant as c where c.participant = :component", [component: this])
 
     events_to_delete.each {
@@ -1376,6 +1378,7 @@ where cp.owner = :c
     if (this?.class == CuratoryGroup) {
       AllocatedReviewGroup.removeAll(this)
     }
+    AllocatedReviewGroup.executeUpdate("delete from AllocatedReviewGroup as grp where grp.review in  as c where c.componentToReview=:component", [component: this]);
     ReviewRequest.executeUpdate("delete from ReviewRequest as c where c.componentToReview=:component", [component: this]);
     ComponentPerson.executeUpdate("delete from ComponentPerson as c where c.component=:component", [component: this]);
     ComponentSubject.executeUpdate("delete from ComponentSubject as c where c.component=:component", [component: this]);


### PR DESCRIPTION
Longer Timeout for OaiController.getRecord and OaiController.listRecords
KBComponent expunges AllocatedReviewGroup relation before deleting the ReviewRequest to prevent violating a foreignKeyConstraint