### PR TITLE
138 remove zdb enrichment option

### DIFF
--- a/server/gokbg3/grails-app/domain/org/gokb/cred/Source.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/Source.groovy
@@ -20,7 +20,6 @@ class Source extends KBComponent {
   RefdataValue defaultDataFormat
   IdentifierNamespace targetNamespace
   Date lastRun
-  Boolean zdbMatch = false
   Boolean ezbMatch = false
   Org responsibleParty
 
@@ -47,7 +46,6 @@ class Source extends KBComponent {
     targetNamespace(nullable:true, blank:true)
     lastRun(nullable:true,default: null)
     ezbMatch(nullable:true, default: false)
-    zdbMatch(nullable:true,default: false)
     automaticUpdates(nullable: true,default: false)
     name(validator: { val, obj ->
       if (obj.hasChanged('name')) {
@@ -126,7 +124,6 @@ class Source extends KBComponent {
       builder.'ruleset' (ruleset)
       builder.'automaticUpdates' (automaticUpdates)
       builder.'ezbMatch' (ezbMatch)
-      builder.'zdbMatch' (zdbMatch)
       builder.'lastRun' (lastRun)
       if ( targetNamespace ) {
         builder.'targetNamespace'('namespaceName': targetNamespace.name, 'value': targetNamespace.value, 'id': targetNamespace.id)

--- a/server/gokbg3/grails-app/services/org/gokb/PackageService.groovy
+++ b/server/gokbg3/grails-app/services/org/gokb/PackageService.groovy
@@ -1163,7 +1163,6 @@ class PackageService {
                 url            : sourceMap.url,
                 frequency      : sourceMap.frequency,
                 ezbMatch       : (sourceMap.ezbMatch ?: false),
-                zdbMatch       : (sourceMap.zdbMatch ?: false),
                 automaticUpdate: (sourceMap.automaticUpdate ?: false),
                 targetNamespace: namespace
             ]
@@ -1180,7 +1179,6 @@ class PackageService {
             changed |= ClassUtils.setStringIfDifferent(src, 'frequency', sourceMap.frequency)
             changed |= ClassUtils.setStringIfDifferent(src, 'url', sourceMap.url)
             changed |= ClassUtils.setBooleanIfDifferent(src, 'ezbMatch', sourceMap.ezbMatch)
-            changed |= ClassUtils.setBooleanIfDifferent(src, 'zdbMatch', sourceMap.zdbMatch)
             changed |= ClassUtils.setBooleanIfDifferent(src, 'automaticUpdate', sourceMap.automaticUpdate)
 
             if (namespace && namespace != src.targetNamespace) {

--- a/server/gokbg3/grails-app/views/apptemplates/_source.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_source.gsp
@@ -44,7 +44,7 @@
 			</g:manyToOneReferenceTypedown>
 		</dd>
 		<dt>
-			<g:annotatedLabel owner="${d}" property="zdbMatch">Automated Updates</g:annotatedLabel>
+			<g:annotatedLabel owner="${d}" property="automaticUpdates">Automated Updates</g:annotatedLabel>
 		</dt>
 		<dd>
 			<g:xEditableBoolean owner="${d}" field="automaticUpdates" />

--- a/server/gokbg3/grails-app/views/apptemplates/_source.gsp
+++ b/server/gokbg3/grails-app/views/apptemplates/_source.gsp
@@ -62,12 +62,6 @@
 			<g:xEditableBoolean owner="${d}" field="ezbMatch" />
 		</dd>
 		<dt>
-			<g:annotatedLabel owner="${d}" property="zdbMatch">ZDB Matching Enabled</g:annotatedLabel>
-		</dt>
-		<dd>
-			<g:xEditableBoolean owner="${d}" field="zdbMatch" />
-		</dd>
-		<dt>
 			<g:annotatedLabel owner="${d}" property="lastRun">Last Run</g:annotatedLabel>
 		</dt>
 		<dd>


### PR DESCRIPTION
Removed the `zdbMatch` option completely, assuming that the later-on ZDB enrichment is active for each package and shall not be configurable.