### PR TITLE
added mapping between UpdateToken and User

### DIFF
--- a/server/gokbg3/grails-app/domain/org/gokb/cred/User.groovy
+++ b/server/gokbg3/grails-app/domain/org/gokb/cred/User.groovy
@@ -41,7 +41,8 @@ class User extends Party {
     updateTokens: UpdateToken
   ]
 
-  static mappedBy = [curatoryGroups: "users"]
+  static mappedBy = [curatoryGroups: "users",
+                     updateTokens: "updateUser"]
 
   static constraints = {
     username(blank: false, unique: true)


### PR DESCRIPTION
beim Testen ist mir aufgefallen, dass hibernate sich über ein fehlendes Mapping beschwert. Weil es fehlt. Komisch, dass Grails das irgendwie so auflösen konnte, aber jetzt ist es 'richtig'.