### PR TITLE
Fix MissingPropertyException (context of GOKbIT-355)

### DIFF
--- a/server/gokbg3/grails-app/controllers/org/gokb/rest/OrgController.groovy
+++ b/server/gokbg3/grails-app/controllers/org/gokb/rest/OrgController.groovy
@@ -111,8 +111,8 @@ class OrgController {
     def errors = [:]
     def user = User.get(springSecurityService.principal.id)
 
+    def obj = null
     if (reqBody) {
-      def obj = null
       def lookup_result = orgService.restLookup(reqBody)
 
       if (lookup_result.to_create) {


### PR DESCRIPTION
`obj` was a "missing property" at the end of that method.